### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Redis MCP Server
 [![smithery badge](https://smithery.ai/badge/@redis/mcp-redis)](https://smithery.ai/server/@redis/mcp-redis)
+
+<a href="https://glama.ai/mcp/servers/@redis/mcp-redis">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@redis/mcp-redis/badge" alt="Redis Server MCP server" />
+</a>
+
 ## Overview
 The Redis MCP Server is a **natural language interface** designed for agentic applications to efficiently manage and search data in Redis. It integrates seamlessly with **MCP (Model Content Protocol) clients**, enabling AI-driven workflows to interact with structured and unstructured data in Redis. Using this MCP Server, you can ask questions like:
 
@@ -33,7 +38,6 @@ Additional tools.
 - `query engine` tools to manage vector indexes and perform vector search
 - `server management` tool to retrieve information about the database
 
-
 ## Installation
 
 ### Installing via Smithery
@@ -55,7 +59,6 @@ uv venv
 source .venv/bin/activate
 uv sync
 ```
-
 
 ## Configuration
 
@@ -162,4 +165,3 @@ This project is licensed under the **MIT License**.
 
 ## Contact
 For questions or support, reach out via [GitHub Issues](https://github.com/redis/mcp-redis/issues).
-


### PR DESCRIPTION
This PR adds a badge for the [Redis MCP Server](https://glama.ai/mcp/servers/@redis/mcp-redis) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@redis/mcp-redis">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@redis/mcp-redis/badge" alt="Redis Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.