### PR TITLE
Remove unnecessary decode calls in Redis operations

### DIFF
--- a/src/tools/hash.py
+++ b/src/tools/hash.py
@@ -43,7 +43,7 @@ async def hget(name: str, key: str) -> str:
     try:
         r = RedisConnectionManager.get_connection()
         value = r.hget(name, key)
-        return value.decode() if value else f"Field '{key}' not found in hash '{name}'."
+        return value if value else f"Field '{key}' not found in hash '{name}'."
     except RedisError as e:
         return f"Error getting field '{key}' from hash '{name}': {str(e)}"
 

--- a/src/tools/list.py
+++ b/src/tools/list.py
@@ -32,7 +32,7 @@ async def lpop(name: str) -> str:
     try:
         r = RedisConnectionManager.get_connection()
         value = r.lpop(name)
-        return value.decode() if value else f"List '{name}' is empty or does not exist."
+        return value if value else f"List '{name}' is empty or does not exist."
     except RedisError as e:
         return f"Error popping value from list '{name}': {str(e)}"
 
@@ -42,7 +42,7 @@ async def rpop(name: str) -> str:
     try:
         r = RedisConnectionManager.get_connection()
         value = r.rpop(name)
-        return value.decode() if value else f"List '{name}' is empty or does not exist."
+        return value if value else f"List '{name}' is empty or does not exist."
     except RedisError as e:
         return f"Error popping value from list '{name}': {str(e)}"
 
@@ -52,7 +52,7 @@ async def lrange(name: str, start: int, stop: int) -> list:
     try:
         r = RedisConnectionManager.get_connection()
         values = r.lrange(name, start, stop)
-        return [v.decode() for v in values] if values else f"List '{name}' is empty or does not exist."
+        return [v for v in values] if values else f"List '{name}' is empty or does not exist."
     except RedisError as e:
         return f"Error retrieving values from list '{name}': {str(e)}"
 

--- a/src/tools/misc.py
+++ b/src/tools/misc.py
@@ -34,7 +34,7 @@ async def type(key: str) -> Dict[str, Any]:
     """
     try:
         r = RedisConnectionManager.get_connection()
-        key_type = r.type(key).decode('utf-8')
+        key_type = r.type(key)
         info = {
             'key': key,
             'type': key_type,


### PR DESCRIPTION
## Issue
When `RedisConnectionManager.get_connection()` is configured with `decode_responses=True`, the Redis client automatically returns string values. However, some methods unnecessarily call `.decode()` on these already-decoded string values, resulting in an AttributeError: 'str' object has no attribute 'decode'.

## Fix
Removed .decode() calls in the following methods:
* `lpop` 
* `rpop` 
* `lrange`
* `hget` 
* `type` 