### PR TITLE
lrange: convert output list to JSON

### DIFF
--- a/src/tools/list.py
+++ b/src/tools/list.py
@@ -1,3 +1,4 @@
+import json
 from common.connection import RedisConnectionManager
 from redis.exceptions import RedisError
 from common.server import mcp
@@ -48,11 +49,18 @@ async def rpop(name: str) -> str:
 
 @mcp.tool()
 async def lrange(name: str, start: int, stop: int) -> list:
-    """Get elements from a Redis list within a specific range."""
+    """Get elements from a Redis list within a specific range.
+
+        Returns:
+        str: A JSON string containing the list of elements or an error message.
+    """
     try:
         r = RedisConnectionManager.get_connection()
         values = r.lrange(name, start, stop)
-        return [v for v in values] if values else f"List '{name}' is empty or does not exist."
+        if not values:
+            return f"List '{name}' is empty or does not exist."
+        else:
+            return json.dumps(values)
     except RedisError as e:
         return f"Error retrieving values from list '{name}': {str(e)}"
 


### PR DESCRIPTION
`lrange` tools has a similar issue reported for `get_indexes` in #10

```sh
127.0.0.1:6379> lrange mylist 0 -1
1) "item1:item10:item11"
2) "item1"
3) "item2"
4) "item3"
```

> Please give the items in the list: mylist
> The items currently in the mylist list are: item1, item10, item11, item1, item2, and item3. If you need to modify or inspect this list further, let me know!

This PR uses the same fix used for `get_indexes`, converting the output list to JSON.