### PR TITLE
fix: update smithery yaml to use uv

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -51,8 +51,8 @@ startCommand:
     # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
     |-
     (config) => ({
-      command: 'python',
-      args: ['src/main.py'],
+      command: 'uv',
+      args: ['run', 'python', 'src/main.py'],
       env: {
         REDIS_HOST: config.redisHost,
         REDIS_PORT: String(config.redisPort),


### PR DESCRIPTION
This commit fixes server startup by updating smithery yaml to be in sync with the docker image (which uses uv). Example successful deployment: https://smithery.ai/server/@arjunkmrm/mcp-redis