### PR TITLE
Fix `json_set()` `value` argument type

### DIFF
--- a/src/tools/json.py
+++ b/src/tools/json.py
@@ -1,9 +1,7 @@
 from common.connection import RedisConnectionManager
 from redis.exceptions import RedisError
 from common.server import mcp
-from typing import Any, Dict, List, Union
-
-JsonType = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
+from redis.commands.json._util import JsonType
 
 
 @mcp.tool()

--- a/src/tools/json.py
+++ b/src/tools/json.py
@@ -1,10 +1,13 @@
 from common.connection import RedisConnectionManager
 from redis.exceptions import RedisError
 from common.server import mcp
+from typing import Any, Dict, List, Union
+
+JsonType = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
 
 
 @mcp.tool()
-async def json_set(name: str, path: str, value: str, expire_seconds: int = None) -> str:
+async def json_set(name: str, path: str, value: JsonType, expire_seconds: int = None) -> str:
     """Set a JSON value in Redis at a given path with an optional expiration time.
 
     Args:


### PR DESCRIPTION
Current behavior:
`json_set` fails trying to set a numeric value:

**Example:**
In Redis server, create a new json document user:100 with two fields: name, age add random values to them.

**GitHub Copilot**

Ran json_set - my-mcp-redis-server (MCP Server)

Input
```python
{
  "name": "user:100",
  "path": "$",
  "value": "{\"name\": \"Alice\", \"age\": 27}"
}
```

Output
```python
Error executing tool json_set: 1 validation error for json_setArguments
value
  Input should be a valid string [type=string_type, input_value={'name': 'Alice', 'age': 27}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/string_type
```

Change:
The type of `json_set` `value` argument is changed to `JsonType`.
The definition of `JsonType` is the same used by redis-py

https://github.com/redis/redis-py/blob/36619a507addc313c0245bf318e4678938fc5d44/redis/commands/json/_util.py#L3
