### PR TITLE
Fix `rpush()` and `lpush()`

### DIFF
--- a/src/tools/list.py
+++ b/src/tools/list.py
@@ -2,9 +2,10 @@ import json
 from common.connection import RedisConnectionManager
 from redis.exceptions import RedisError
 from common.server import mcp
+from redis.typing import FieldT
 
 @mcp.tool()
-async def lpush(name: str, value: str, expire: int = None) -> str:
+async def lpush(name: str, value: FieldT, expire: int = None) -> str:
     """Push a value onto the left of a Redis list and optionally set an expiration time."""
     try:
         r = RedisConnectionManager.get_connection()
@@ -16,7 +17,7 @@ async def lpush(name: str, value: str, expire: int = None) -> str:
         return f"Error pushing value to list '{name}': {str(e)}"
 
 @mcp.tool()
-async def rpush(name: str, value: str, expire: int = None) -> str:
+async def rpush(name: str, value: FieldT, expire: int = None) -> str:
     """Push a value onto the right of a Redis list and optionally set an expiration time."""
     try:
         r = RedisConnectionManager.get_connection()


### PR DESCRIPTION
**Current behavior:**
`rpush` and `lpush` fail trying to set a numeric value

**Example:**
create a list of 3 random numbers between 0 and 10

**GitHub Copilot**
Ran rpush -my-mcp-redis-server (MCP Server)

**Input**
```json
{
  "name": "random:numbers:list:1",
  "value": "7"
}
```
**Output**
```python
Error executing tool rpush: 1 validation error for rpushArguments
value
  Input should be a valid string [type=string_type, input_value=7, input_type=int]
    For further information visit https://errors.pydantic.dev/2.10/v/string_type
```

**Change:**
Change type of `value` to `FieldT`.