### PR TITLE
fix(cli): handle whitespace-only Redis_URL properly

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -55,8 +55,8 @@ def cli(
 ):
     """Redis MCP Server - Model Context Protocol server for Redis."""
 
-    # Handle Redis URI if provided
-    if url:
+    # Handle Redis URI if provided (and not empty)
+    if url and url.strip():
         try:
             uri_config = parse_redis_uri(url)
             set_redis_config_from_cli(uri_config)


### PR DESCRIPTION
## Summary
Fixes validation of Redis URL parameter to properly handle whitespace-only values. Previously, URLs containing only whitespace characters would pass validation but cause parsing errors.

## Changes
- Added `url.strip()` check in CLI URL validation
- Prevents processing of empty or whitespace-only URLs
- Maintains existing behavior for valid URLs

## Testing
- [x] Tested with empty string URL
- [x] Tested with whitespace-only URL (`"   "`, `"\n\t"`)
- [x] Tested with valid URLs (no regression)
- [x] Existing tests pass

## Example
```bash
# Before: Would cause parsing error
redis-mcp-server --url "   "

# After: Gracefully skips invalid URL and uses defaults
redis-mcp-server --url "   "