### PR TITLE
fix: handle literal  string when env var is unset

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -56,7 +56,9 @@ def cli(
     """Redis MCP Server - Model Context Protocol server for Redis."""
 
     # Handle Redis URI if provided (and not empty)
-    if url and url.strip():
+    # Note: gemini-cli passes the raw "${REDIS_URL}" string when the env var is not set
+
+    if url and url.strip() and url.strip() != "${REDIS_URL}":
         try:
             uri_config = parse_redis_uri(url)
             set_redis_config_from_cli(uri_config)


### PR DESCRIPTION
## Fix: Handle literal `${REDIS_URL}` string when environment variable is unset

### Problem
When the `REDIS_URL` environment variable is not set, gemini-cli passes the raw `"${REDIS_URL}"` string as the `--url` parameter instead of omitting it or passing an empty value. This causes the Redis MCP server to attempt parsing the literal string `"${REDIS_URL}"` as a Redis URI, which fails with a parsing error.

### Root Cause
The issue occurs because:
1. gemini-cli constructs command line arguments that include `--url ${REDIS_URL}`
2. When `REDIS_URL` is unset, shell expansion doesn't occur, so the literal string `"${REDIS_URL}"` gets passed
3. The server tries to parse this as a valid Redis URI, which fails

### Solution
Filter out the `"${REDIS_URL}"` placeholder string.
This allows the server to gracefully fall back to using individual Redis connection parameters (host, port, etc.) with their default values when no valid URL is provided.

### Impact

- Fixes Redis MCP server startup failures when installed from PyPI and used with gemini-cli
- Maintains backward compatibility with existing configurations
- No breaking changes to the API or configuration options