### PR TITLE
docs: reference #redis-mcp-server Discord channel in contact section

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,3 +550,5 @@ This project is licensed under the **MIT License**.
 
 ## Contact
 For questions or support, reach out via [GitHub Issues](https://github.com/redis/mcp-redis/issues).
+
+Alternatively, you can join the [Redis Discord server](https://discord.gg/redis) and ask in the `#redis-mcp-server` channel.


### PR DESCRIPTION
## Summary
Updates Discord contact info to direct users to the `#redis-mcp-server` channel for MCP-specific support.

## Changes
- Updated Contact section to reference `#redis-mcp-server` Discord channel
- Uses the general Redis Discord invite link to ensure all users can join

## Type of Change
- [x] Documentation update