### PR TITLE
Add Python 3.14 to test matrix to match Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     services:
       redis:
@@ -151,7 +151,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - name: ⚙️ Checkout the project

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@
       needs: validate-release
       strategy:
         matrix:
-          python-version: ["3.10", "3.11", "3.12", "3.13"]
+          python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
   
       services:
         redis:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Redis MCP Server
 [![Integration](https://github.com/redis/mcp-redis/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/redis/mcp-redis/actions/workflows/ci.yml)
 [![PyPI - Version](https://img.shields.io/pypi/v/redis-mcp-server)](https://pypi.org/project/redis-mcp-server/)
-[![Python Version](https://img.shields.io/badge/python-3.13%2B-blue&logo=redis)](https://www.python.org/downloads/)
+[![Python Version](https://img.shields.io/badge/python-3.14%2B-blue&logo=redis)](https://www.python.org/downloads/)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE.txt)
 [![Verified on MseeP](https://mseep.ai/badge.svg)](https://mseep.ai/app/70102150-efe0-4705-9f7d-87980109a279)
 [![Docker Image Version](https://img.shields.io/docker/v/mcp/redis?sort=semver&logo=docker&label=Docker)](https://hub.docker.com/r/mcp/redis)
@@ -148,7 +148,7 @@ pip install redis-mcp-server
 And start it using `uv` the package in your environment.
 
 ```sh
-uv python install 3.13
+uv python install 3.14
 uv sync
 uv run redis-mcp-server --url redis://localhost:6379/0
 ```
@@ -439,7 +439,7 @@ export OPENAI_API_KEY="<openai_token>"
 And run the [application](./examples/redis_assistant.py).
 
 ```commandline
-python3.13 redis_assistant.py
+python3.14 redis_assistant.py
 ```
 
 You can troubleshoot your agent workflows using the [OpenAI dashboard](https://platform.openai.com/traces/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Database",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]


### PR DESCRIPTION
## Fix Python version inconsistency between Dockerfile and test matrix

### Problem
The Dockerfile uses `python:3.14-slim`, but the CI/CD test matrices only tested against Python versions 3.10-3.13, creating a gap between the production environment and testing coverage.

### Changes
- Add Python 3.14 to CI workflow test matrix (`.github/workflows/ci.yml`)
- Add Python 3.14 to release workflow test matrix (`.github/workflows/release.yml`)
- Add Python 3.14 classifier to `pyproject.toml`
- Update README badge and examples to reference Python 3.14

### Testing
All existing tests will now run against Python 3.14 in addition to the previous versions.