### PR TITLE
Rename extension from 'mcp-redis' to 'redis'

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,7 @@
 {
-  "name": "mcp-redis",
+  "name": "redis",
   "version": "0.1.0",
+  "description": "Manage and search data in Redis efficiently within Gemini CLI.",
   "mcpServers": {
     "redis": {
       "command": "uvx",


### PR DESCRIPTION
Gemini CLI team member here 👋 

Gemini CLI extensions can be much more than just MCP servers, for that reason we highly recommend removing mcp from their names and instead just use the product (aka redis).

That way users leveraging the extension don't actually need to even know what MCP is 😄

Also the description field in the `gemini-extension.json` populates the tile card for the extension in our gallery: https://geminicli.com/extensions/

## Current

<img width="492" height="342" alt="image" src="https://github.com/user-attachments/assets/18d2efaf-d116-4465-834d-3d6a8cf254cf" />

## Proposed
<img width="487" height="343" alt="image" src="https://github.com/user-attachments/assets/52f76e25-94b8-41c2-b542-925b87c0290b" />

I also recommend adding a custom context file (`REDIS.md`) with best practices for improving Redis workflows and some custom commands to streamline workflows for users. This would take the extension to the next level. 🚀 