### PR TITLE
feat: add MCP registry metadata for server publication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM python:3.14-slim
+
+LABEL io.modelcontextprotocol.server.name="io.github.redis/mcp-redis"
+
 RUN pip install --upgrade uv
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Redis MCP Server
+
+<!-- mcp-name: io.github.redis/mcp-redis -->
+
 [![Integration](https://github.com/redis/mcp-redis/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/redis/mcp-redis/actions/workflows/ci.yml)
 [![PyPI - Version](https://img.shields.io/pypi/v/redis-mcp-server)](https://pypi.org/project/redis-mcp-server/)
 [![Python Version](https://img.shields.io/badge/python-3.14%2B-blue&logo=redis)](https://www.python.org/downloads/)

--- a/server.json
+++ b/server.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "name": "io.github.redis/mcp-redis",
+  "title": "Redis MCP Server",
+  "description": "Natural language interface designed for agentic applications to manage and search data in Redis.",
+  "version": "0.3.5",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "redis-mcp-server",
+      "version": "0.3.5",
+      "transport": {
+        "type": "stdio"
+      }
+    },
+    {
+      "registryType": "oci",
+      "identifier": "docker.io/mcp/redis:latest",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}
+


### PR DESCRIPTION
## Summary

This PR adds the necessary metadata files and configuration for publishing the Redis MCP Server to the [MCP registry](https://github.com/modelcontextprotocol/registry) following [those instructions](https://techwithibrahim.medium.com/how-to-publish-your-mcp-server-to-the-official-registry-a-complete-guide-3622f0edceef).

## Changes

- **`server.json`**: Added MCP server manifest with metadata including name, description, version, and configuration schema
- **`README.md`**: Added `mcp-name` identifier (`io.github.redis/mcp-redis`) for registry recognition
- **`Dockerfile`**: Updated with registry-compatible configuration

## Purpose

These changes enable the Redis MCP Server to be discoverable and installable through the official MCP registry, making it easier for users to find and integrate the server into their MCP-compatible applications.

## Related

Part of the effort to publish the Redis MCP Server to the official MCP registry for broader community access.