### PR TITLE
fix: add REDIS_URL in gemini-extension as a setting

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -18,7 +18,8 @@
     {
       "name": "Redis URL",
       "description": "Connection URL for your Redis instance (e.g., redis://localhost:6379/0)",
-      "envVar": "REDIS_URL"
+      "envVar": "REDIS_URL",
+      "sensitive": true
     }
   ]
 }


### PR DESCRIPTION
Gemini extensions [now support settings](https://developers.googleblog.com/making-gemini-cli-extensions-easier-to-use/) making it easier to take in user inputs.

Earlier, it is very easy to forget setting REDIS_URL as the env variable making the Redis extension installation fail. With Gemini extension settings,  the user is prompted to set Redis URL making the experience seamless.

Screenshot showing extension installation waiting for user input for Redis URL:
<img width="1258" height="280" alt="Screenshot 2026-02-17 at 6 06 07 PM" src="https://github.com/user-attachments/assets/3bf6b0b5-32f2-4f24-a50b-29fc67393ffb" />

Screenshot post successful installation:
<img width="1254" height="310" alt="Screenshot 2026-02-17 at 6 06 20 PM" src="https://github.com/user-attachments/assets/8ebe54f1-7c9c-46ba-b421-e73962b9dd68" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the extension manifest to define a `REDIS_URL` setting and adjusts JSON formatting, with no runtime logic changes.
> 
> **Overview**
> Adds a `settings` entry to `gemini-extension.json` that exposes `REDIS_URL` as a *sensitive* “Redis URL” configuration value, so Gemini CLI can prompt users for it instead of relying on a pre-set env var.
> 
> Also normalizes the `--url` argument formatting in the manifest (no behavioral change beyond surfacing the setting).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa97b584363907c19fd428294d3c905ea54aee59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->