### PR TITLE
Add stream consumer group tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This MCP Server provides tools to manage the data stored in Redis.
 - `set` tools to add, remove and list set members. Useful for tracking unique values like user IDs or tags, and for performing set operations like intersection.
 - `sorted set` tools to manage data for e.g. leaderboards, priority queues, or time-based analytics with score-based ordering.
 - `pub/sub` functionality to publish messages to channels and subscribe to receive them. Useful for real-time notifications, chat applications, or distributing updates to multiple clients.
-- `streams` tools to add, read, and delete from data streams. Useful for event sourcing, activity feeds, or sensor data logging with consumer groups support.
+- `streams` tools to add, read, delete, create consumer groups, and acknowledge processed entries in data streams. Useful for event sourcing, activity feeds, and worker-based event processing with Redis Streams consumer groups.
 - `JSON` tools to store, retrieve, and manipulate JSON documents in Redis. Useful for complex nested data structures, document databases, or configuration management with path-based access.
 
 Additional tools.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This MCP Server provides tools to manage the data stored in Redis.
 - `set` tools to add, remove and list set members. Useful for tracking unique values like user IDs or tags, and for performing set operations like intersection.
 - `sorted set` tools to manage data for e.g. leaderboards, priority queues, or time-based analytics with score-based ordering.
 - `pub/sub` functionality to publish messages to channels and subscribe to receive them. Useful for real-time notifications, chat applications, or distributing updates to multiple clients.
-- `streams` tools to add, read, delete, create consumer groups, and acknowledge processed entries in data streams. Useful for event sourcing, activity feeds, and worker-based event processing with Redis Streams consumer groups.
+- `streams` tools to add, read, delete, create and destroy consumer groups, and acknowledge processed entries in data streams. Useful for event sourcing, activity feeds, and worker-based event processing with Redis Streams consumer groups.
 - `JSON` tools to store, retrieve, and manipulate JSON documents in Redis. Useful for complex nested data structures, document databases, or configuration management with path-based access.
 
 Additional tools.

--- a/src/tools/stream.py
+++ b/src/tools/stream.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
 
 from redis.exceptions import RedisError
 
@@ -72,3 +72,106 @@ async def xdel(key: str, entry_id: str) -> str:
         )
     except RedisError as e:
         return f"Error deleting from stream {key}: {str(e)}"
+
+
+@mcp.tool()
+async def xgroup_create(
+    key: str,
+    group_name: str,
+    start_id: str = "$",
+    mkstream: bool = True,
+) -> str:
+    """Create a consumer group for a Redis stream.
+
+    Args:
+        key (str): The stream key.
+        group_name (str): The consumer group name.
+        start_id (str, optional): Stream ID from which the group starts consuming.
+        mkstream (bool, optional): Create the stream if it does not exist.
+
+    Returns:
+        str: Confirmation message or an error message.
+    """
+    try:
+        r = RedisConnectionManager.get_connection()
+        r.xgroup_create(key, group_name, id=start_id, mkstream=mkstream)
+        return f"Successfully created consumer group '{group_name}' on stream '{key}'"
+    except RedisError as e:
+        return (
+            f"Error creating consumer group '{group_name}' on stream '{key}': {str(e)}"
+        )
+
+
+@mcp.tool()
+async def xreadgroup(
+    key: str,
+    group_name: str,
+    consumer_name: str,
+    count: int = 1,
+    block_ms: Optional[int] = None,
+    stream_id: str = ">",
+) -> str:
+    """Read entries from a Redis stream using a consumer group.
+
+    Args:
+        key (str): The stream key.
+        group_name (str): The consumer group name.
+        consumer_name (str): The consumer name.
+        count (int, optional): Maximum number of entries to retrieve.
+        block_ms (int, optional): Maximum time to block waiting for entries.
+        stream_id (str, optional): Stream ID to read from. Use ">" for new messages.
+
+    Returns:
+        str: The retrieved stream entries or an error message.
+    """
+    try:
+        r = RedisConnectionManager.get_connection()
+        entries = r.xreadgroup(
+            group_name,
+            consumer_name,
+            {key: stream_id},
+            count=count,
+            block=block_ms,
+        )
+        return (
+            str(entries)
+            if entries
+            else (
+                f"No entries available for consumer '{consumer_name}' in group "
+                f"'{group_name}' on stream '{key}'"
+            )
+        )
+    except RedisError as e:
+        return (
+            f"Error reading from stream {key} with consumer group '{group_name}': "
+            f"{str(e)}"
+        )
+
+
+@mcp.tool()
+async def xack(key: str, group_name: str, entry_ids: List[str]) -> str:
+    """Acknowledge entries that were processed by a consumer group.
+
+    Args:
+        key (str): The stream key.
+        group_name (str): The consumer group name.
+        entry_ids (List[str]): Entry IDs to acknowledge.
+
+    Returns:
+        str: Confirmation message or an error message.
+    """
+    if not entry_ids:
+        return "At least one entry ID is required to acknowledge stream entries"
+
+    try:
+        r = RedisConnectionManager.get_connection()
+        acknowledged = r.xack(key, group_name, *entry_ids)
+        return (
+            f"Successfully acknowledged {acknowledged} entr"
+            f"{'y' if acknowledged == 1 else 'ies'} in group '{group_name}' on stream '{key}'"
+        )
+    except RedisError as e:
+        return (
+            f"Error acknowledging entries for consumer group '{group_name}' on stream "
+            f"'{key}': {str(e)}"
+        )

--- a/src/tools/stream.py
+++ b/src/tools/stream.py
@@ -119,11 +119,16 @@ async def xreadgroup(
         consumer_name (str): The consumer name.
         count (int, optional): Maximum number of entries to retrieve.
         block_ms (int, optional): Maximum time to block waiting for entries.
+            Use None for a non-blocking read. 0 is rejected because Redis treats
+            BLOCK 0 as an indefinite wait.
         stream_id (str, optional): Stream ID to read from. Use ">" for new messages.
 
     Returns:
         str: The retrieved stream entries or an error message.
     """
+    if block_ms == 0:
+        return "block_ms=0 is not allowed; use None for a non-blocking read or a positive timeout in milliseconds"
+
     try:
         r = RedisConnectionManager.get_connection()
         entries = r.xreadgroup(

--- a/src/tools/stream.py
+++ b/src/tools/stream.py
@@ -154,7 +154,7 @@ async def xreadgroup(
     if block_ms == 0:
         return "block_ms=0 is not allowed; use None for a non-blocking read or a positive timeout in milliseconds"
     if block_ms is not None and block_ms < 0:
-        return "block_ms must be greater than or equal to 0"
+        return "block_ms must be greater than 0 milliseconds when provided"
     if block_ms is not None and block_ms > 5000:
         return "block_ms must be less than or equal to 5000 milliseconds"
 

--- a/src/tools/stream.py
+++ b/src/tools/stream.py
@@ -103,6 +103,31 @@ async def xgroup_create(
 
 
 @mcp.tool()
+async def xgroup_destroy(key: str, group_name: str) -> str:
+    """Destroy a consumer group for a Redis stream.
+
+    Args:
+        key (str): The stream key.
+        group_name (str): The consumer group name.
+
+    Returns:
+        str: Confirmation message or an error message.
+    """
+    try:
+        r = RedisConnectionManager.get_connection()
+        result = r.xgroup_destroy(key, group_name)
+        return (
+            f"Successfully destroyed consumer group '{group_name}' on stream '{key}'"
+            if result
+            else f"Consumer group '{group_name}' not found on stream '{key}'"
+        )
+    except RedisError as e:
+        return (
+            f"Error destroying consumer group '{group_name}' on stream '{key}': {str(e)}"
+        )
+
+
+@mcp.tool()
 async def xreadgroup(
     key: str,
     group_name: str,
@@ -126,8 +151,14 @@ async def xreadgroup(
     Returns:
         str: The retrieved stream entries or an error message.
     """
+    if count < 1:
+        return "count must be greater than 0"
     if block_ms == 0:
         return "block_ms=0 is not allowed; use None for a non-blocking read or a positive timeout in milliseconds"
+    if block_ms is not None and block_ms < 0:
+        return "block_ms must be greater than or equal to 0"
+    if block_ms is not None and block_ms > 5000:
+        return "block_ms must be less than or equal to 5000 milliseconds"
 
     try:
         r = RedisConnectionManager.get_connection()

--- a/src/tools/stream.py
+++ b/src/tools/stream.py
@@ -122,9 +122,7 @@ async def xgroup_destroy(key: str, group_name: str) -> str:
             else f"Consumer group '{group_name}' not found on stream '{key}'"
         )
     except RedisError as e:
-        return (
-            f"Error destroying consumer group '{group_name}' on stream '{key}': {str(e)}"
-        )
+        return f"Error destroying consumer group '{group_name}' on stream '{key}': {str(e)}"
 
 
 @mcp.tool()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -236,6 +236,9 @@ class TestMCPServerIntegration:
             "zrange",
             "zrem",
             "xadd",
+            "xgroup_create",
+            "xreadgroup",
+            "xack",
             "xrange",
             "xdel",
             "set",
@@ -243,9 +246,9 @@ class TestMCPServerIntegration:
             "lrem",
         ]
         for tool in tool_names:
-            assert tool in expected_tools, (
-                f"Expected tool '{tool}' not found in {tool_names}"
-            )
+            assert (
+                tool in expected_tools
+            ), f"Expected tool '{tool}' not found in {tool_names}"
 
     def test_server_tool_count_and_names(self, server_process):
         """Test that the server registers the correct number of tools with expected names."""
@@ -271,10 +274,10 @@ class TestMCPServerIntegration:
         tool_names = [tool["name"] for tool in tools]
 
         # Expected tool count (based on @mcp.tool() decorators in codebase)
-        expected_tool_count = 47
-        assert len(tools) == expected_tool_count, (
-            f"Expected {expected_tool_count} tools, but got {len(tools)}"
-        )
+        expected_tool_count = 50
+        assert (
+            len(tools) == expected_tool_count
+        ), f"Expected {expected_tool_count} tools, but got {len(tools)}"
 
         # Expected tool names (alphabetically sorted for easier verification)
         expected_tools = [
@@ -319,9 +322,12 @@ class TestMCPServerIntegration:
             "type",
             "unsubscribe",
             "vector_search_hash",
+            "xack",
             "xadd",
             "xdel",
+            "xgroup_create",
             "xrange",
+            "xreadgroup",
             "zadd",
             "zrange",
             "zrem",
@@ -341,7 +347,7 @@ class TestMCPServerIntegration:
             "list": ["lpush", "rpush", "lpop", "rpop", "lrange", "llen"],
             "set": ["sadd", "srem", "smembers"],
             "sorted_set": ["zadd", "zrem", "zrange"],
-            "stream": ["xadd", "xdel", "xrange"],
+            "stream": ["xadd", "xdel", "xgroup_create", "xrange", "xreadgroup", "xack"],
             "json": ["json_get", "json_set", "json_del"],
             "pub_sub": ["publish", "subscribe", "unsubscribe"],
             "server_mgmt": ["dbsize", "info", "client_list"],
@@ -367,9 +373,9 @@ class TestMCPServerIntegration:
 
         for category, category_tools in tool_categories.items():
             for tool in category_tools:
-                assert tool in tool_names, (
-                    f"Tool '{tool}' from category '{category}' not found in registered tools"
-                )
+                assert (
+                    tool in tool_names
+                ), f"Tool '{tool}' from category '{category}' not found in registered tools"
 
     def _initialize_server(self, server_process):
         """Helper to initialize the MCP server."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -246,9 +246,9 @@ class TestMCPServerIntegration:
             "lrem",
         ]
         for tool in tool_names:
-            assert (
-                tool in expected_tools
-            ), f"Expected tool '{tool}' not found in {tool_names}"
+            assert tool in expected_tools, (
+                f"Expected tool '{tool}' not found in {tool_names}"
+            )
 
     def test_server_tool_count_and_names(self, server_process):
         """Test that the server registers the correct number of tools with expected names."""
@@ -275,9 +275,9 @@ class TestMCPServerIntegration:
 
         # Expected tool count (based on @mcp.tool() decorators in codebase)
         expected_tool_count = 50
-        assert (
-            len(tools) == expected_tool_count
-        ), f"Expected {expected_tool_count} tools, but got {len(tools)}"
+        assert len(tools) == expected_tool_count, (
+            f"Expected {expected_tool_count} tools, but got {len(tools)}"
+        )
 
         # Expected tool names (alphabetically sorted for easier verification)
         expected_tools = [
@@ -373,9 +373,9 @@ class TestMCPServerIntegration:
 
         for category, category_tools in tool_categories.items():
             for tool in category_tools:
-                assert (
-                    tool in tool_names
-                ), f"Tool '{tool}' from category '{category}' not found in registered tools"
+                assert tool in tool_names, (
+                    f"Tool '{tool}' from category '{category}' not found in registered tools"
+                )
 
     def _initialize_server(self, server_process):
         """Helper to initialize the MCP server."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -237,6 +237,7 @@ class TestMCPServerIntegration:
             "zrem",
             "xadd",
             "xgroup_create",
+            "xgroup_destroy",
             "xreadgroup",
             "xack",
             "xrange",
@@ -274,7 +275,7 @@ class TestMCPServerIntegration:
         tool_names = [tool["name"] for tool in tools]
 
         # Expected tool count (based on @mcp.tool() decorators in codebase)
-        expected_tool_count = 50
+        expected_tool_count = 51
         assert len(tools) == expected_tool_count, (
             f"Expected {expected_tool_count} tools, but got {len(tools)}"
         )
@@ -326,6 +327,7 @@ class TestMCPServerIntegration:
             "xadd",
             "xdel",
             "xgroup_create",
+            "xgroup_destroy",
             "xrange",
             "xreadgroup",
             "zadd",
@@ -347,7 +349,15 @@ class TestMCPServerIntegration:
             "list": ["lpush", "rpush", "lpop", "rpop", "lrange", "llen"],
             "set": ["sadd", "srem", "smembers"],
             "sorted_set": ["zadd", "zrem", "zrange"],
-            "stream": ["xadd", "xdel", "xgroup_create", "xrange", "xreadgroup", "xack"],
+            "stream": [
+                "xadd",
+                "xdel",
+                "xgroup_create",
+                "xgroup_destroy",
+                "xrange",
+                "xreadgroup",
+                "xack",
+            ],
             "json": ["json_get", "json_set", "json_del"],
             "pub_sub": ["publish", "subscribe", "unsubscribe"],
             "server_mgmt": ["dbsize", "info", "client_list"],

--- a/tests/tools/test_stream.py
+++ b/tests/tools/test_stream.py
@@ -347,7 +347,9 @@ class TestStreamOperations:
         """Test consumer-group read rejects excessively large block_ms values."""
         mock_redis = mock_redis_connection_manager
 
-        result = await xreadgroup("test_stream", "workers", "consumer-1", block_ms=300000)
+        result = await xreadgroup(
+            "test_stream", "workers", "consumer-1", block_ms=300000
+        )
 
         mock_redis.xreadgroup.assert_not_called()
         assert result == "block_ms must be less than or equal to 5000 milliseconds"

--- a/tests/tools/test_stream.py
+++ b/tests/tools/test_stream.py
@@ -271,6 +271,21 @@ class TestStreamOperations:
         )
 
     @pytest.mark.asyncio
+    async def test_xreadgroup_rejects_zero_block_ms(
+        self, mock_redis_connection_manager
+    ):
+        """Test that block_ms=0 is rejected to avoid indefinite blocking."""
+        mock_redis = mock_redis_connection_manager
+
+        result = await xreadgroup("test_stream", "workers", "consumer-1", block_ms=0)
+
+        mock_redis.xreadgroup.assert_not_called()
+        assert result == (
+            "block_ms=0 is not allowed; use None for a non-blocking read or a "
+            "positive timeout in milliseconds"
+        )
+
+    @pytest.mark.asyncio
     async def test_xreadgroup_redis_error(self, mock_redis_connection_manager):
         """Test consumer-group read with Redis error."""
         mock_redis = mock_redis_connection_manager

--- a/tests/tools/test_stream.py
+++ b/tests/tools/test_stream.py
@@ -7,7 +7,15 @@ from unittest.mock import Mock, patch
 import pytest
 from redis.exceptions import RedisError
 
-from src.tools.stream import xack, xadd, xdel, xgroup_create, xrange, xreadgroup
+from src.tools.stream import (
+    xack,
+    xadd,
+    xdel,
+    xgroup_create,
+    xgroup_destroy,
+    xrange,
+    xreadgroup,
+)
 
 
 class TestStreamOperations:
@@ -211,6 +219,44 @@ class TestStreamOperations:
         ) == result
 
     @pytest.mark.asyncio
+    async def test_xgroup_destroy_success(self, mock_redis_connection_manager):
+        """Test successful consumer group destroy."""
+        mock_redis = mock_redis_connection_manager
+        mock_redis.xgroup_destroy.return_value = 1
+
+        result = await xgroup_destroy("test_stream", "workers")
+
+        mock_redis.xgroup_destroy.assert_called_once_with("test_stream", "workers")
+        assert (
+            result
+            == "Successfully destroyed consumer group 'workers' on stream 'test_stream'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_xgroup_destroy_group_not_found(self, mock_redis_connection_manager):
+        """Test consumer group destroy when group does not exist."""
+        mock_redis = mock_redis_connection_manager
+        mock_redis.xgroup_destroy.return_value = 0
+
+        result = await xgroup_destroy("test_stream", "workers")
+
+        mock_redis.xgroup_destroy.assert_called_once_with("test_stream", "workers")
+        assert result == "Consumer group 'workers' not found on stream 'test_stream'"
+
+    @pytest.mark.asyncio
+    async def test_xgroup_destroy_redis_error(self, mock_redis_connection_manager):
+        """Test consumer group destroy with Redis error."""
+        mock_redis = mock_redis_connection_manager
+        mock_redis.xgroup_destroy.side_effect = RedisError("NOGROUP No such key")
+
+        result = await xgroup_destroy("test_stream", "workers")
+
+        assert (
+            "Error destroying consumer group 'workers' on stream 'test_stream': "
+            "NOGROUP No such key"
+        ) == result
+
+    @pytest.mark.asyncio
     async def test_xreadgroup_success(self, mock_redis_connection_manager):
         """Test successful consumer-group read."""
         mock_redis = mock_redis_connection_manager
@@ -256,6 +302,55 @@ class TestStreamOperations:
             block=1000,
         )
         assert result == str(mock_entries)
+
+    @pytest.mark.asyncio
+    async def test_xreadgroup_count_validation(self, mock_redis_connection_manager):
+        """Test consumer-group read validates count > 0."""
+        mock_redis = mock_redis_connection_manager
+
+        result = await xreadgroup("test_stream", "workers", "consumer-1", count=0)
+
+        mock_redis.xreadgroup.assert_not_called()
+        assert result == "count must be greater than 0"
+
+    @pytest.mark.asyncio
+    async def test_xreadgroup_block_ms_negative_validation(
+        self, mock_redis_connection_manager
+    ):
+        """Test consumer-group read rejects negative block_ms values."""
+        mock_redis = mock_redis_connection_manager
+
+        result = await xreadgroup("test_stream", "workers", "consumer-1", block_ms=-1)
+
+        mock_redis.xreadgroup.assert_not_called()
+        assert result == "block_ms must be greater than or equal to 0"
+
+    @pytest.mark.asyncio
+    async def test_xreadgroup_block_ms_zero_validation(
+        self, mock_redis_connection_manager
+    ):
+        """Test consumer-group read rejects block_ms=0."""
+        mock_redis = mock_redis_connection_manager
+
+        result = await xreadgroup("test_stream", "workers", "consumer-1", block_ms=0)
+
+        mock_redis.xreadgroup.assert_not_called()
+        assert result == (
+            "block_ms=0 is not allowed; use None for a non-blocking read or a "
+            "positive timeout in milliseconds"
+        )
+
+    @pytest.mark.asyncio
+    async def test_xreadgroup_block_ms_upper_bound_validation(
+        self, mock_redis_connection_manager
+    ):
+        """Test consumer-group read rejects excessively large block_ms values."""
+        mock_redis = mock_redis_connection_manager
+
+        result = await xreadgroup("test_stream", "workers", "consumer-1", block_ms=300000)
+
+        mock_redis.xreadgroup.assert_not_called()
+        assert result == "block_ms must be less than or equal to 5000 milliseconds"
 
     @pytest.mark.asyncio
     async def test_xreadgroup_empty_result(self, mock_redis_connection_manager):
@@ -477,6 +572,11 @@ class TestStreamOperations:
         assert xgroup_create_params == ["key", "group_name", "start_id", "mkstream"]
         assert xgroup_create_sig.parameters["start_id"].default == "$"
         assert xgroup_create_sig.parameters["mkstream"].default is True
+
+        # Test xgroup_destroy function signature
+        xgroup_destroy_sig = inspect.signature(xgroup_destroy)
+        xgroup_destroy_params = list(xgroup_destroy_sig.parameters.keys())
+        assert xgroup_destroy_params == ["key", "group_name"]
 
         # Test xreadgroup function signature
         xreadgroup_sig = inspect.signature(xreadgroup)

--- a/tests/tools/test_stream.py
+++ b/tests/tools/test_stream.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 import pytest
 from redis.exceptions import RedisError
 
-from src.tools.stream import xadd, xdel, xrange
+from src.tools.stream import xack, xadd, xdel, xgroup_create, xrange, xreadgroup
 
 
 class TestStreamOperations:
@@ -160,6 +160,189 @@ class TestStreamOperations:
         assert "Error deleting from stream test_stream: Connection failed" in result
 
     @pytest.mark.asyncio
+    async def test_xgroup_create_success(self, mock_redis_connection_manager):
+        """Test successful consumer group creation."""
+        mock_redis = mock_redis_connection_manager
+        mock_redis.xgroup_create.return_value = True
+
+        result = await xgroup_create("test_stream", "workers")
+
+        mock_redis.xgroup_create.assert_called_once_with(
+            "test_stream", "workers", id="$", mkstream=True
+        )
+        assert (
+            result
+            == "Successfully created consumer group 'workers' on stream 'test_stream'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_xgroup_create_with_custom_options(
+        self, mock_redis_connection_manager
+    ):
+        """Test consumer group creation with explicit start ID and no stream creation."""
+        mock_redis = mock_redis_connection_manager
+        mock_redis.xgroup_create.return_value = True
+
+        result = await xgroup_create(
+            "test_stream", "workers", start_id="0-0", mkstream=False
+        )
+
+        mock_redis.xgroup_create.assert_called_once_with(
+            "test_stream", "workers", id="0-0", mkstream=False
+        )
+        assert (
+            result
+            == "Successfully created consumer group 'workers' on stream 'test_stream'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_xgroup_create_redis_error(self, mock_redis_connection_manager):
+        """Test consumer group creation with Redis error."""
+        mock_redis = mock_redis_connection_manager
+        mock_redis.xgroup_create.side_effect = RedisError(
+            "BUSYGROUP Consumer Group name already exists"
+        )
+
+        result = await xgroup_create("test_stream", "workers")
+
+        assert (
+            "Error creating consumer group 'workers' on stream 'test_stream': "
+            "BUSYGROUP Consumer Group name already exists"
+        ) == result
+
+    @pytest.mark.asyncio
+    async def test_xreadgroup_success(self, mock_redis_connection_manager):
+        """Test successful consumer-group read."""
+        mock_redis = mock_redis_connection_manager
+        mock_entries = [
+            ("test_stream", [("1234567890123-0", {"field1": "value1"})]),
+        ]
+        mock_redis.xreadgroup.return_value = mock_entries
+
+        result = await xreadgroup("test_stream", "workers", "consumer-1")
+
+        mock_redis.xreadgroup.assert_called_once_with(
+            "workers",
+            "consumer-1",
+            {"test_stream": ">"},
+            count=1,
+            block=None,
+        )
+        assert result == str(mock_entries)
+
+    @pytest.mark.asyncio
+    async def test_xreadgroup_with_count_and_block(self, mock_redis_connection_manager):
+        """Test consumer-group read with count and blocking options."""
+        mock_redis = mock_redis_connection_manager
+        mock_entries = [
+            ("test_stream", [("1234567890124-0", {"field1": "value2"})]),
+        ]
+        mock_redis.xreadgroup.return_value = mock_entries
+
+        result = await xreadgroup(
+            "test_stream",
+            "workers",
+            "consumer-1",
+            count=5,
+            block_ms=1000,
+            stream_id="0",
+        )
+
+        mock_redis.xreadgroup.assert_called_once_with(
+            "workers",
+            "consumer-1",
+            {"test_stream": "0"},
+            count=5,
+            block=1000,
+        )
+        assert result == str(mock_entries)
+
+    @pytest.mark.asyncio
+    async def test_xreadgroup_empty_result(self, mock_redis_connection_manager):
+        """Test consumer-group read when no entries are available."""
+        mock_redis = mock_redis_connection_manager
+        mock_redis.xreadgroup.return_value = []
+
+        result = await xreadgroup("test_stream", "workers", "consumer-1")
+
+        assert (
+            result
+            == "No entries available for consumer 'consumer-1' in group 'workers' on stream 'test_stream'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_xreadgroup_redis_error(self, mock_redis_connection_manager):
+        """Test consumer-group read with Redis error."""
+        mock_redis = mock_redis_connection_manager
+        mock_redis.xreadgroup.side_effect = RedisError("NOGROUP No such key")
+
+        result = await xreadgroup("test_stream", "workers", "consumer-1")
+
+        assert (
+            "Error reading from stream test_stream with consumer group 'workers': "
+            "NOGROUP No such key"
+        ) == result
+
+    @pytest.mark.asyncio
+    async def test_xack_success(self, mock_redis_connection_manager):
+        """Test successful acknowledgment of stream entries."""
+        mock_redis = mock_redis_connection_manager
+        mock_redis.xack.return_value = 2
+
+        result = await xack(
+            "test_stream", "workers", ["1234567890123-0", "1234567890124-0"]
+        )
+
+        mock_redis.xack.assert_called_once_with(
+            "test_stream", "workers", "1234567890123-0", "1234567890124-0"
+        )
+        assert (
+            result
+            == "Successfully acknowledged 2 entries in group 'workers' on stream 'test_stream'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_xack_single_entry_success(self, mock_redis_connection_manager):
+        """Test successful acknowledgment of a single stream entry."""
+        mock_redis = mock_redis_connection_manager
+        mock_redis.xack.return_value = 1
+
+        result = await xack("test_stream", "workers", ["1234567890123-0"])
+
+        mock_redis.xack.assert_called_once_with(
+            "test_stream", "workers", "1234567890123-0"
+        )
+        assert (
+            result
+            == "Successfully acknowledged 1 entry in group 'workers' on stream 'test_stream'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_xack_requires_entry_ids(self, mock_redis_connection_manager):
+        """Test acknowledgment validation when no entry IDs are supplied."""
+        mock_redis = mock_redis_connection_manager
+
+        result = await xack("test_stream", "workers", [])
+
+        mock_redis.xack.assert_not_called()
+        assert (
+            result == "At least one entry ID is required to acknowledge stream entries"
+        )
+
+    @pytest.mark.asyncio
+    async def test_xack_redis_error(self, mock_redis_connection_manager):
+        """Test acknowledgment with Redis error."""
+        mock_redis = mock_redis_connection_manager
+        mock_redis.xack.side_effect = RedisError("NOGROUP No such key")
+
+        result = await xack("test_stream", "workers", ["1234567890123-0"])
+
+        assert (
+            "Error acknowledging entries for consumer group 'workers' on stream "
+            "'test_stream': NOGROUP No such key"
+        ) == result
+
+    @pytest.mark.asyncio
     async def test_xadd_with_empty_fields(self, mock_redis_connection_manager):
         """Test stream add operation with empty fields dictionary."""
         mock_redis = mock_redis_connection_manager
@@ -272,6 +455,33 @@ class TestStreamOperations:
         xdel_sig = inspect.signature(xdel)
         xdel_params = list(xdel_sig.parameters.keys())
         assert xdel_params == ["key", "entry_id"]
+
+        # Test xgroup_create function signature
+        xgroup_create_sig = inspect.signature(xgroup_create)
+        xgroup_create_params = list(xgroup_create_sig.parameters.keys())
+        assert xgroup_create_params == ["key", "group_name", "start_id", "mkstream"]
+        assert xgroup_create_sig.parameters["start_id"].default == "$"
+        assert xgroup_create_sig.parameters["mkstream"].default is True
+
+        # Test xreadgroup function signature
+        xreadgroup_sig = inspect.signature(xreadgroup)
+        xreadgroup_params = list(xreadgroup_sig.parameters.keys())
+        assert xreadgroup_params == [
+            "key",
+            "group_name",
+            "consumer_name",
+            "count",
+            "block_ms",
+            "stream_id",
+        ]
+        assert xreadgroup_sig.parameters["count"].default == 1
+        assert xreadgroup_sig.parameters["block_ms"].default is None
+        assert xreadgroup_sig.parameters["stream_id"].default == ">"
+
+        # Test xack function signature
+        xack_sig = inspect.signature(xack)
+        xack_params = list(xack_sig.parameters.keys())
+        assert xack_params == ["key", "group_name", "entry_ids"]
 
     @pytest.mark.asyncio
     async def test_xadd_with_complex_fields(self, mock_redis_connection_manager):

--- a/tests/tools/test_stream.py
+++ b/tests/tools/test_stream.py
@@ -323,7 +323,7 @@ class TestStreamOperations:
         result = await xreadgroup("test_stream", "workers", "consumer-1", block_ms=-1)
 
         mock_redis.xreadgroup.assert_not_called()
-        assert result == "block_ms must be greater than or equal to 0"
+        assert result == "block_ms must be greater than 0 milliseconds when provided"
 
     @pytest.mark.asyncio
     async def test_xreadgroup_block_ms_zero_validation(
@@ -365,21 +365,6 @@ class TestStreamOperations:
         assert (
             result
             == "No entries available for consumer 'consumer-1' in group 'workers' on stream 'test_stream'"
-        )
-
-    @pytest.mark.asyncio
-    async def test_xreadgroup_rejects_zero_block_ms(
-        self, mock_redis_connection_manager
-    ):
-        """Test that block_ms=0 is rejected to avoid indefinite blocking."""
-        mock_redis = mock_redis_connection_manager
-
-        result = await xreadgroup("test_stream", "workers", "consumer-1", block_ms=0)
-
-        mock_redis.xreadgroup.assert_not_called()
-        assert result == (
-            "block_ms=0 is not allowed; use None for a non-blocking read or a "
-            "positive timeout in milliseconds"
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

  This PR adds core Redis Streams consumer-group operations to the Redis MCP Server:

  - xgroup_create
  - xreadgroup
  - xack

  Redis already supports these commands, but mcp-redis only exposed xadd, xrange, and xdel. That meant MCP clients could write to streams and inspect them, but could not use Redis Streams for
  coordinated worker-style processing.

  ## Why

  The current stream tools support basic append/read/delete workflows, but they do not support the main Redis Streams pattern for distributed processing: consumer groups.

  Example:

  - With xadd + xrange, multiple workers can read the same stream entries, but Redis does not track ownership or completion.
  - With consumer groups, workers can read via xreadgroup, Redis tracks delivery to a specific consumer, and completed entries can be acknowledged with xack.

  This is useful for asynchronous and inference-adjacent workflows such as:

  - background job processing
  - embedding pipelines
  - document ingestion
  - multi-worker event handling
  - agent-triggered async task execution

  ## What Changed

  - Added xgroup_create to create a consumer group for a stream
  - Added xreadgroup to read stream entries through a consumer group
  - Added xack to acknowledge processed entries
  - Added unit tests for success cases, validation, and Redis error handling
  - Updated integration tests for MCP tool registration
  - Updated the README stream-tools description

  ## Validation

  Ran locally:
  uv run black src/tools/stream.py tests/tools/test_stream.py tests/test_integration.py
  uv run ruff check src/tools/stream.py tests/tools/test_stream.py tests/test_integration.py
  uv run pytest

  Result:
  - 321 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new MCP-exposed Redis Streams consumer-group operations (`XGROUP`/`XREADGROUP`/`XACK`), which may affect clients’ available tool surface and introduces new input-validation paths for blocking reads.
> 
> **Overview**
> Adds Redis Streams consumer-group support to the MCP server by introducing new tools: `xgroup_create`, `xgroup_destroy`, `xreadgroup`, and `xack` (including validation for `count` and `block_ms` and consistent Redis error-to-string handling).
> 
> Updates documentation to reflect the expanded Streams toolset, and extends unit/integration tests to assert tool registration, updated tool count, tool categorization, and new success/error/validation behaviors for the added stream consumer-group operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7afb1921000f3b9f36b9d5a2d48b04cb27c8c46c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->