### PR TITLE
chore: upgrade redis-entraid to 1.1.2 for security fixes

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1949,11 +1949,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.10.1"
+version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [package.optional-dependencies]
@@ -2199,7 +2202,7 @@ wheels = [
 
 [[package]]
 name = "redis-entraid"
-version = "1.1.0"
+version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-identity" },
@@ -2207,9 +2210,9 @@ dependencies = [
     { name = "pyjwt" },
     { name = "redis" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/f3/49df8f999bc80f51440836cf217a7ee43e991ac11af13cd4efdf0a64c39c/redis_entraid-1.1.0.tar.gz", hash = "sha256:700403401c3950f0f3dbda12fb26cf269b421bac47e3b56baf90354dc22d8d00", size = 9733, upload-time = "2025-12-11T08:25:50.645Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/09/744b8b0ef5b1b06fa132615f1ce5b87ea6118a3259fdeed7491cdbdc1cc2/redis_entraid-1.1.2.tar.gz", hash = "sha256:95c9cb8a779e79f60ec1abfaf51daf78e3731d8621851d2bfa5ca7b1fd8177ab", size = 9787, upload-time = "2026-03-26T14:52:11.674Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/20/7524da8bc7747bc6a80009839eb3212979ea964d3c4b1c7d87dbcd719579/redis_entraid-1.1.0-py3-none-any.whl", hash = "sha256:7bd995da24f57121cb54cb5912d68539ac09ade93aadf8887c994174fd255587", size = 7960, upload-time = "2025-12-11T08:25:49.435Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/94/ac01b9b719d5f0d320df7980fc49228a280774c50bcdf3265422523ead7a/redis_entraid-1.1.2-py3-none-any.whl", hash = "sha256:81fb2fb3b095cd3d01fba4f39543d9deefdf7f41ec732767297926cd3b0ac1a4", size = 7961, upload-time = "2026-03-26T14:52:10.615Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Upgrades `redis-entraid` from 1.1.0 to 1.1.2 to address known security vulnerabilities.

### Changes
Updated `uv.lock` to pin `redis-entraid` 1.1.2
Transitive bump of `pyjwt` from 2.10.1 to 2.12.1
### Notes
No code changes — lock file only
The dependency spec in `pyproject.toml` (>=1.0.0) already allows this version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Lockfile-only dependency bump, but it updates JWT/auth-related libraries (`redis-entraid`/`pyjwt`) which could change token validation behavior at runtime.
> 
> **Overview**
> Upgrades the lockfile to pin `redis-entraid` from `1.1.0` to `1.1.2`.
> 
> As part of the resolved dependency graph, `pyjwt` is bumped from `2.10.1` to `2.12.1` (now pulling `typing-extensions` on Python <3.11). No application code changes are included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c90ee35af88f3ca742ce5319d65408525a40b1cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->