### PR TITLE
add redis topology support and improve mcp deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked
 
 # Support environment variable configuration for transport and bind address.
-ENV TRANSPORT=streamable-http
+ENV TRANSPORT=stdio
 ENV HTTP_HOST=0.0.0.0
 ENV HTTP_PORT=8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.14-slim
 
 LABEL io.modelcontextprotocol.server.name="io.github.redis/mcp-redis"
+LABEL description="Redis MCP Server with support for multiple transport protocols"
+LABEL transport.supported="stdio,http,sse,streamable-http"
 
 RUN pip install --upgrade uv
 
@@ -9,4 +11,9 @@ COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked
 
-CMD ["uv", "run", "python", "src/main.py"]
+# Support environment variable configuration for transport and bind address.
+ENV TRANSPORT=streamable-http
+ENV HTTP_HOST=0.0.0.0
+ENV HTTP_PORT=8000
+
+ENTRYPOINT ["uv", "run", "redis-mcp-server"]

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The Redis MCP Server is a **natural language interface** designed for agentic ap
 - **Search & Filtering**: Supports efficient data retrieval and searching in Redis.
 - **Scalable & Lightweight**: Designed for **high-performance** data operations.
 - **EntraID Authentication**: Native support for Azure Active Directory authentication with Azure Managed Redis.
-- The Redis MCP Server supports the `stdio` [transport](https://modelcontextprotocol.io/docs/concepts/transports#standard-input%2Foutput-stdio). Support to the `stremable-http` transport will be added in the future.
+- **Multiple Transport Protocols**: Supports `stdio`, `http`, `sse`, and `streamable-http` [transports](https://modelcontextprotocol.io/docs/concepts/transports) for different deployment scenarios. The `http` CLI option runs the MCP Streamable HTTP endpoint at `/mcp`.
 
 ## Tools
 
@@ -259,8 +259,60 @@ If you'd like to build your own image, the Redis MCP Server provides a Dockerfil
 docker build -t mcp-redis .
 ```
 
-Finally, configure the client to create the container at start-up. An example for Claude Desktop is provided below. Edit the `claude_desktop_config.json` and add:
+#### Docker Transport Protocol Support
 
+The Docker image supports multiple transport protocols through environment variables:
+
+```bash
+# stdio transport (default)
+docker run --rm \
+  -e REDIS_HOST=redis \
+  -e REDIS_PORT=6379 \
+  mcp-redis
+
+# Sentinel-backed Redis connection
+docker run --rm -p 8000:8000 \
+  -e TRANSPORT=streamable-http \
+  -e HTTP_HOST=0.0.0.0 \
+  -e HTTP_PORT=8000 \
+  -e REDIS_TOPOLOGY=sentinel \
+  -e REDIS_SENTINEL_MASTER_NAME=mymaster \
+  -e REDIS_SENTINEL_NODES=sentinel-1:26379,sentinel-2:26379 \
+  mcp-redis
+
+# HTTP transport (served at /mcp)
+docker run --rm -p 8000:8000 \
+  -e TRANSPORT=http \
+  -e HTTP_HOST=0.0.0.0 \
+  -e HTTP_PORT=8000 \
+  -e REDIS_HOST=redis \
+  -e REDIS_PORT=6379 \
+  mcp-redis
+
+# SSE transport
+docker run --rm -p 8000:8000 \
+  -e TRANSPORT=sse \
+  -e HTTP_HOST=0.0.0.0 \
+  -e HTTP_PORT=8000 \
+  -e REDIS_HOST=redis \
+  -e REDIS_PORT=6379 \
+  mcp-redis
+
+# streamable-http transport
+docker run --rm -p 8000:8000 \
+  -e TRANSPORT=streamable-http \
+  -e HTTP_HOST=0.0.0.0 \
+  -e HTTP_PORT=8000 \
+  -e REDIS_HOST=redis \
+  -e REDIS_PORT=6379 \
+  mcp-redis
+```
+
+#### Claude Desktop Configuration
+
+Configure the client to create the container at start-up. Edit the `claude_desktop_config.json` and add:
+
+**Basic Redis connection (stdio transport):**
 ```json
 {
   "mcpServers": {
@@ -281,12 +333,86 @@ Finally, configure the client to create the container at start-up. An example fo
 }
 ```
 
+**HTTP transport for web applications (`/mcp`):**
+```json
+{
+  "mcpServers": {
+    "redis": {
+      "command": "docker",
+      "args": ["run",
+                "--rm",
+                "--name",
+                "redis-mcp-server-http",
+                "-p", "8000:8000",
+                "-e", "TRANSPORT=http",
+                "-e", "HTTP_HOST=0.0.0.0",
+                "-e", "HTTP_PORT=8000",
+                "-e", "REDIS_HOST=<redis_hostname>",
+                "-e", "REDIS_PORT=<redis_port>",
+                "-e", "REDIS_USERNAME=<redis_username>",
+                "-e", "REDIS_PWD=<redis_password>",
+                "mcp-redis"]
+    }
+  }
+}
+```
+
 To use the official [Redis MCP Docker](https://hub.docker.com/r/mcp/redis) image, just replace your image name (`mcp-redis` in the example above) with `mcp/redis`.
 
 ## Configuration
 
 The Redis MCP Server can be configured in two ways: via command line arguments or via environment variables.
 The precedence is: command line arguments > environment variables > default values.
+
+### Transport Protocols
+
+The Redis MCP Server supports multiple transport protocols for different deployment scenarios:
+
+- **stdio** (default): Standard input/output transport, recommended for most MCP clients
+- **http**: Streamable HTTP transport for web-based integrations and microservices, served at `/mcp`
+- **sse**: Server-Sent Events transport for real-time web applications
+- **streamable-http**: Equivalent to `http`, provided as an explicit FastMCP transport name
+
+#### Transport Protocol Selection
+
+```bash
+# Use stdio transport (default)
+redis-mcp-server --url redis://localhost:6379/0
+
+# Use HTTP transport
+redis-mcp-server --transport http --http-host 0.0.0.0 --http-port 8000 --url redis://localhost:6379/0
+
+# Use SSE transport
+redis-mcp-server --transport sse --http-host 0.0.0.0 --http-port 8000 --url redis://localhost:6379/0
+
+# Use streamable-http transport
+redis-mcp-server --transport streamable-http --http-host 0.0.0.0 --http-port 8000 --url redis://localhost:6379/0
+```
+
+#### Transport Use Cases
+
+- **stdio**: Best for local development, CLI tools, and traditional MCP clients
+- **http**: Ideal for web applications, REST APIs, and service-oriented architectures
+- **sse**: Perfect for real-time updates, live dashboards, and event-driven applications
+- **streamable-http**: Same transport as `http`, useful when you want to use the underlying FastMCP naming explicitly
+
+#### HTTP/SSE Transport Configuration
+
+When using HTTP, SSE, or streamable-http transports, you can customize:
+
+- `--http-host`: Host address for the HTTP server (default: 127.0.0.1)
+- `--http-port`: Port for the HTTP server (default: 8000)
+
+The CLI also reads `TRANSPORT`, `HTTP_HOST`, and `HTTP_PORT` environment variables. For FastMCP-native deployments, `FASTMCP_HOST` and `FASTMCP_PORT` are also supported.
+
+Examples:
+```bash
+# Custom host and port for HTTP transport
+redis-mcp-server --transport http --http-host 192.168.1.100 --http-port 9000 --url redis://localhost:6379/0
+
+# Expose HTTP server on all interfaces
+redis-mcp-server --transport http --http-host 0.0.0.0 --http-port 8080 --url redis://localhost:6379/0
+```
 
 ### Redis ACL
 
@@ -323,6 +449,7 @@ uvx --from redis-mcp-server@latest redis-mcp-server --help
 
 **Available CLI Options:**
 - `--url` - Redis connection URI (redis://user:pass@host:port/db)
+- `--topology` - Redis topology: `standalone`, `sentinel`, or `cluster`
 - `--host` - Redis hostname (default: 127.0.0.1)
 - `--port` - Redis port (default: 6379)
 - `--db` - Redis database number (default: 0)
@@ -334,7 +461,30 @@ uvx --from redis-mcp-server@latest redis-mcp-server --help
 - `--ssl-certfile` - Path to SSL certificate file
 - `--ssl-cert-reqs` - SSL certificate requirements (default: required)
 - `--ssl-ca-certs` - Path to CA certificates file
-- `--cluster-mode` - Enable Redis cluster mode
+- `--cluster-mode` - Enable Redis cluster mode (legacy compatibility flag)
+- `--sentinel-master-name` - Sentinel master name
+- `--sentinel-nodes` - Comma-separated Sentinel nodes (`host:port,host:port`)
+- `--sentinel-host` / `--sentinel-port` - Single Sentinel endpoint alternative
+- `--sentinel-username` / `--sentinel-password` - Optional Sentinel authentication
+
+**Topology examples:**
+```bash
+# Standalone (default)
+uvx --from redis-mcp-server@latest redis-mcp-server \
+  --host localhost --port 6379
+
+# Sentinel: the server connects to the Redis master discovered through Sentinel
+uvx --from redis-mcp-server@latest redis-mcp-server \
+  --topology sentinel \
+  --sentinel-master-name mymaster \
+  --sentinel-nodes sentinel-1:26379,sentinel-2:26379
+
+# Cluster
+uvx --from redis-mcp-server@latest redis-mcp-server \
+  --topology cluster \
+  --host redis-cluster.example.com \
+  --port 6379
+```
 
 ### Configuration via Environment Variables
 
@@ -345,6 +495,7 @@ If desired, you can use environment variables. Defaults are provided for all var
 | `REDIS_HOST`         | Redis IP or hostname                                      | `"127.0.0.1"` |
 | `REDIS_PORT`         | Redis port                                                | `6379`        |
 | `REDIS_DB`           | Database                                                  | 0             |
+| `REDIS_TOPOLOGY`     | Redis topology: `standalone`, `sentinel`, `cluster`      | `"standalone"`|
 | `REDIS_USERNAME`     | Default database username                                 | `"default"`   |
 | `REDIS_PWD`          | Default database password                                 | ""            |
 | `REDIS_SSL`          | Enables or disables SSL/TLS                               | `False`       |
@@ -353,7 +504,13 @@ If desired, you can use environment variables. Defaults are provided for all var
 | `REDIS_SSL_CERTFILE` | Client's certificate file for client authentication       | None          |
 | `REDIS_SSL_CERT_REQS`| Whether the client should verify the server's certificate | `"required"`  |
 | `REDIS_SSL_CA_CERTS` | Path to the trusted CA certificates file                  | None          |
-| `REDIS_CLUSTER_MODE` | Enable Redis Cluster mode                                 | `False`       |
+| `REDIS_CLUSTER_MODE` | Enable Redis Cluster mode (legacy compatibility flag)     | `False`       |
+| `REDIS_SENTINEL_MASTER_NAME` | Sentinel master name                             | None          |
+| `REDIS_SENTINEL_NODES` | Comma-separated Sentinel nodes (`host:port,...`)       | None          |
+| `REDIS_SENTINEL_USERNAME` | Sentinel username if Sentinel requires auth         | None          |
+| `REDIS_SENTINEL_PWD` | Sentinel password if Sentinel requires auth               | None          |
+
+Sentinel mode uses Sentinel only for master discovery. Once discovered, the MCP server executes commands against the Redis master instead of the Sentinel endpoint itself.
 
 
 ### EntraID Authentication for Azure Managed Redis
@@ -557,7 +714,7 @@ You can also configure the Redis MCP Server in Augment manually by importing the
 
 The simplest way to configure MCP clients is using `uvx`. Add the following JSON to your `claude_desktop_config.json`, remember to provide the full path to `uvx`.
 
-**Basic Redis connection:**
+**Basic Redis connection (stdio transport):**
 ```json
 {
   "mcpServers": {
@@ -567,6 +724,46 @@ The simplest way to configure MCP clients is using `uvx`. Add the following JSON
         "args": [
             "--from", "redis-mcp-server@latest",
             "redis-mcp-server",
+            "--url", "redis://localhost:6379/0"
+        ]
+    }
+  }
+}
+```
+
+**HTTP transport for web applications (`/mcp`):**
+```json
+{
+  "mcpServers": {
+    "redis-mcp-server": {
+        "type": "stdio",
+        "command": "/Users/mortensi/.local/bin/uvx",
+        "args": [
+            "--from", "redis-mcp-server@latest",
+            "redis-mcp-server",
+            "--transport", "http",
+            "--http-host", "127.0.0.1",
+            "--http-port", "8000",
+            "--url", "redis://localhost:6379/0"
+        ]
+    }
+  }
+}
+```
+
+**SSE transport for real-time applications:**
+```json
+{
+  "mcpServers": {
+    "redis-mcp-server": {
+        "type": "stdio",
+        "command": "/Users/mortensi/.local/bin/uvx",
+        "args": [
+            "--from", "redis-mcp-server@latest",
+            "redis-mcp-server",
+            "--transport", "sse",
+            "--http-host", "127.0.0.1",
+            "--http-port", "8000",
             "--url", "redis://localhost:6379/0"
         ]
     }

--- a/README.md
+++ b/README.md
@@ -264,9 +264,10 @@ docker build -t mcp-redis .
 The Docker image supports multiple transport protocols through environment variables:
 
 ```bash
-# stdio transport (default) - for Claude Desktop and MCP clients
-# stdio 传输协议（默认）- 用于 Claude Desktop 和 MCP 客户端
+# stdio transport - for Claude Desktop and MCP clients
+# stdio 传输协议 - 用于 Claude Desktop 和 MCP 客户端
 docker run --rm -i \
+  -e TRANSPORT=stdio \
   -e REDIS_HOST=redis \
   -e REDIS_PORT=6379 \
   mcp/redis
@@ -317,7 +318,7 @@ docker run --rm -p 8000:8000 \
 
 Configure the client to create the container at start-up. Edit the `claude_desktop_config.json` and add:
 
-**Basic Redis connection (stdio transport - default):**
+**Basic Redis connection (stdio transport):**
 ```json
 {
   "mcpServers": {
@@ -328,6 +329,7 @@ Configure the client to create the container at start-up. Edit the `claude_deskt
                 "--name",
                 "redis-mcp-server",
                 "-i",
+                "-e", "TRANSPORT=stdio",
                 "-e", "REDIS_HOST=<redis_hostname>",
                 "-e", "REDIS_PORT=<redis_port>",
                 "-e", "REDIS_USERNAME=<redis_username>",

--- a/README.md
+++ b/README.md
@@ -264,55 +264,60 @@ docker build -t mcp-redis .
 The Docker image supports multiple transport protocols through environment variables:
 
 ```bash
-# stdio transport (default)
-docker run --rm \
+# stdio transport (default) - for Claude Desktop and MCP clients
+# stdio 传输协议（默认）- 用于 Claude Desktop 和 MCP 客户端
+docker run --rm -i \
   -e REDIS_HOST=redis \
   -e REDIS_PORT=6379 \
-  mcp-redis
+  mcp/redis
 
-# Sentinel-backed Redis connection
-docker run --rm -p 8000:8000 \
-  -e TRANSPORT=streamable-http \
-  -e HTTP_HOST=0.0.0.0 \
-  -e HTTP_PORT=8000 \
-  -e REDIS_TOPOLOGY=sentinel \
-  -e REDIS_SENTINEL_MASTER_NAME=mymaster \
-  -e REDIS_SENTINEL_NODES=sentinel-1:26379,sentinel-2:26379 \
-  mcp-redis
-
-# HTTP transport (served at /mcp)
+# HTTP transport for web applications (served at /mcp)
+# HTTP 传输协议用于 Web 应用（在 /mcp 端点提供服务）
 docker run --rm -p 8000:8000 \
   -e TRANSPORT=http \
   -e HTTP_HOST=0.0.0.0 \
   -e HTTP_PORT=8000 \
   -e REDIS_HOST=redis \
   -e REDIS_PORT=6379 \
-  mcp-redis
+  mcp/redis
 
-# SSE transport
+# SSE transport for real-time applications
+# SSE 传输协议用于实时应用
 docker run --rm -p 8000:8000 \
   -e TRANSPORT=sse \
   -e HTTP_HOST=0.0.0.0 \
   -e HTTP_PORT=8000 \
   -e REDIS_HOST=redis \
   -e REDIS_PORT=6379 \
-  mcp-redis
+  mcp/redis
 
-# streamable-http transport
+# Streamable HTTP transport
+# Streamable HTTP 传输协议
 docker run --rm -p 8000:8000 \
   -e TRANSPORT=streamable-http \
   -e HTTP_HOST=0.0.0.0 \
   -e HTTP_PORT=8000 \
   -e REDIS_HOST=redis \
   -e REDIS_PORT=6379 \
-  mcp-redis
+  mcp/redis
+
+# Sentinel-backed Redis connection with HTTP transport
+# 使用 HTTP 传输协议的 Sentinel 模式 Redis 连接
+docker run --rm -p 8000:8000 \
+  -e TRANSPORT=http \
+  -e HTTP_HOST=0.0.0.0 \
+  -e HTTP_PORT=8000 \
+  -e REDIS_TOPOLOGY=sentinel \
+  -e REDIS_SENTINEL_MASTER_NAME=mymaster \
+  -e REDIS_SENTINEL_NODES=sentinel-1:26379,sentinel-2:26379 \
+  mcp/redis
 ```
 
 #### Claude Desktop Configuration
 
 Configure the client to create the container at start-up. Edit the `claude_desktop_config.json` and add:
 
-**Basic Redis connection (stdio transport):**
+**Basic Redis connection (stdio transport - default):**
 ```json
 {
   "mcpServers": {
@@ -327,7 +332,7 @@ Configure the client to create the container at start-up. Edit the `claude_deskt
                 "-e", "REDIS_PORT=<redis_port>",
                 "-e", "REDIS_USERNAME=<redis_username>",
                 "-e", "REDIS_PWD=<redis_password>",
-                "mcp-redis"]
+                "mcp/redis"]
     }
   }
 }
@@ -351,13 +356,37 @@ Configure the client to create the container at start-up. Edit the `claude_deskt
                 "-e", "REDIS_PORT=<redis_port>",
                 "-e", "REDIS_USERNAME=<redis_username>",
                 "-e", "REDIS_PWD=<redis_password>",
-                "mcp-redis"]
+                "mcp/redis"]
     }
   }
 }
 ```
 
-To use the official [Redis MCP Docker](https://hub.docker.com/r/mcp/redis) image, just replace your image name (`mcp-redis` in the example above) with `mcp/redis`.
+**SSE transport for real-time applications:**
+```json
+{
+  "mcpServers": {
+    "redis": {
+      "command": "docker",
+      "args": ["run",
+                "--rm",
+                "--name",
+                "redis-mcp-server-sse",
+                "-p", "8000:8000",
+                "-e", "TRANSPORT=sse",
+                "-e", "HTTP_HOST=0.0.0.0",
+                "-e", "HTTP_PORT=8000",
+                "-e", "REDIS_HOST=<redis_hostname>",
+                "-e", "REDIS_PORT=<redis_port>",
+                "-e", "REDIS_USERNAME=<redis_username>",
+                "-e", "REDIS_PWD=<redis_password>",
+                "mcp/redis"]
+    }
+  }
+}
+```
+
+To use the official [Redis MCP Docker](https://hub.docker.com/r/mcp/redis) image, just use `mcp/redis` as the image name in the examples above.
 
 ## Configuration
 

--- a/server.json
+++ b/server.json
@@ -14,6 +14,24 @@
       }
     },
     {
+      "registryType": "pypi",
+      "identifier": "redis-mcp-server",
+      "version": "$VERSION",
+      "transport": {
+        "type": "http",
+        "url": "http://localhost:8000/mcp"
+      }
+    },
+    {
+      "registryType": "pypi",
+      "identifier": "redis-mcp-server",
+      "version": "$VERSION",
+      "transport": {
+        "type": "sse",
+        "url": "http://localhost:8000/sse"
+      }
+    },
+    {
       "registryType": "oci",
       "identifier": "docker.io/mcp/redis:latest",
       "transport": {

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -11,21 +11,100 @@ DEFAULT_LOWER_REFRESH_BOUND_MILLIS = 30000  # 30 seconds
 DEFAULT_TOKEN_REQUEST_EXECUTION_TIMEOUT_MS = 10000  # 10 seconds
 DEFAULT_RETRY_MAX_ATTEMPTS = 3
 DEFAULT_RETRY_DELAY_MS = 100
+DEFAULT_SENTINEL_PORT = 26379
 
-REDIS_CFG = {
-    "host": os.getenv("REDIS_HOST", "127.0.0.1"),
-    "port": int(os.getenv("REDIS_PORT", 6379)),
-    "username": os.getenv("REDIS_USERNAME", None),
-    "password": os.getenv("REDIS_PWD", ""),
-    "ssl": os.getenv("REDIS_SSL", False) in ("true", "1", "t"),
-    "ssl_ca_path": os.getenv("REDIS_SSL_CA_PATH", None),
-    "ssl_keyfile": os.getenv("REDIS_SSL_KEYFILE", None),
-    "ssl_certfile": os.getenv("REDIS_SSL_CERTFILE", None),
-    "ssl_cert_reqs": os.getenv("REDIS_SSL_CERT_REQS", "required"),
-    "ssl_ca_certs": os.getenv("REDIS_SSL_CA_CERTS", None),
-    "cluster_mode": os.getenv("REDIS_CLUSTER_MODE", False) in ("true", "1", "t"),
-    "db": int(os.getenv("REDIS_DB", 0)),
-}
+
+def parse_bool(value) -> bool:
+    """Parse a value into a boolean using common truthy strings."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in ("true", "1", "t", "yes", "y", "on")
+
+
+def parse_sentinel_nodes(value) -> list[tuple[str, int]]:
+    """Parse sentinel nodes from a comma-separated string or iterable."""
+    if value in (None, ""):
+        return []
+
+    if isinstance(value, list):
+        nodes = value
+    else:
+        nodes = str(value).split(",")
+
+    parsed_nodes = []
+    for node in nodes:
+        if isinstance(node, tuple):
+            host, port = node
+            parsed_nodes.append((str(host), int(port)))
+            continue
+
+        entry = str(node).strip()
+        if not entry:
+            continue
+
+        if ":" in entry:
+            host, port = entry.rsplit(":", 1)
+            parsed_nodes.append((host.strip(), int(port)))
+        else:
+            parsed_nodes.append((entry, DEFAULT_SENTINEL_PORT))
+
+    return parsed_nodes
+
+
+def normalize_topology(topology=None, cluster_mode=False) -> str:
+    """Resolve the effective Redis topology."""
+    if topology:
+        topology = str(topology).strip().lower()
+        if topology not in {"standalone", "sentinel", "cluster"}:
+            raise ValueError(f"Unsupported topology: {topology}")
+        if cluster_mode and topology != "cluster":
+            raise ValueError(
+                "REDIS_CLUSTER_MODE conflicts with REDIS_TOPOLOGY unless topology=cluster"
+            )
+        return topology
+
+    return "cluster" if parse_bool(cluster_mode) else "standalone"
+
+
+def build_redis_config_from_env() -> dict:
+    """Build Redis configuration from environment variables."""
+    cluster_mode = parse_bool(os.getenv("REDIS_CLUSTER_MODE", False))
+    topology = normalize_topology(os.getenv("REDIS_TOPOLOGY"), cluster_mode)
+
+    sentinel_host = os.getenv("REDIS_SENTINEL_HOST", None)
+    sentinel_port = os.getenv("REDIS_SENTINEL_PORT", None)
+    sentinel_nodes = parse_sentinel_nodes(os.getenv("REDIS_SENTINEL_NODES", None))
+    if sentinel_host:
+        sentinel_nodes.append(
+            (
+                sentinel_host,
+                int(sentinel_port or DEFAULT_SENTINEL_PORT),
+            )
+        )
+
+    return {
+        "host": os.getenv("REDIS_HOST", "127.0.0.1"),
+        "port": int(os.getenv("REDIS_PORT", 6379)),
+        "username": os.getenv("REDIS_USERNAME", None),
+        "password": os.getenv("REDIS_PWD", ""),
+        "ssl": parse_bool(os.getenv("REDIS_SSL", False)),
+        "ssl_ca_path": os.getenv("REDIS_SSL_CA_PATH", None),
+        "ssl_keyfile": os.getenv("REDIS_SSL_KEYFILE", None),
+        "ssl_certfile": os.getenv("REDIS_SSL_CERTFILE", None),
+        "ssl_cert_reqs": os.getenv("REDIS_SSL_CERT_REQS", "required"),
+        "ssl_ca_certs": os.getenv("REDIS_SSL_CA_CERTS", None),
+        "cluster_mode": topology == "cluster",
+        "topology": topology,
+        "db": int(os.getenv("REDIS_DB", 0)),
+        "sentinel_master_name": os.getenv("REDIS_SENTINEL_MASTER_NAME", None),
+        "sentinel_nodes": sentinel_nodes,
+        "sentinel_username": os.getenv("REDIS_SENTINEL_USERNAME", None),
+        "sentinel_password": os.getenv("REDIS_SENTINEL_PWD", None),
+    }
+
+REDIS_CFG = build_redis_config_from_env()
 
 # Entra ID Authentication Configuration
 ENTRAID_CFG = {
@@ -86,7 +165,7 @@ def parse_redis_uri(uri: str) -> dict:
     """Parse a Redis URI and return connection parameters."""
     parsed = urllib.parse.urlparse(uri)
 
-    config = {}
+    config = {"topology": "standalone", "cluster_mode": False}
 
     # Scheme determines SSL
     if parsed.scheme == "rediss":
@@ -143,6 +222,22 @@ def parse_redis_uri(uri: str) -> dict:
             except ValueError:
                 pass
 
+        if "topology" in query_params:
+            config["topology"] = normalize_topology(query_params["topology"][0])
+            config["cluster_mode"] = config["topology"] == "cluster"
+
+        if "cluster_mode" in query_params and parse_bool(query_params["cluster_mode"][0]):
+            config["topology"] = "cluster"
+            config["cluster_mode"] = True
+
+        if "sentinel_master_name" in query_params:
+            config["sentinel_master_name"] = query_params["sentinel_master_name"][0]
+
+        if "sentinel_nodes" in query_params:
+            config["sentinel_nodes"] = parse_sentinel_nodes(
+                query_params["sentinel_nodes"][0]
+            )
+
     return config
 
 
@@ -151,15 +246,56 @@ def set_redis_config_from_cli(config: dict):
         if key in ["port", "db"]:
             # Keep port and db as integers
             REDIS_CFG[key] = int(value)
-        elif key == "ssl" or key == "cluster_mode":
+        elif key in ["ssl", "cluster_mode"]:
             # Keep ssl and cluster_mode as booleans
-            REDIS_CFG[key] = bool(value)
+            REDIS_CFG[key] = parse_bool(value)
+        elif key == "topology":
+            REDIS_CFG[key] = normalize_topology(value, REDIS_CFG.get("cluster_mode"))
+            REDIS_CFG["cluster_mode"] = REDIS_CFG[key] == "cluster"
+        elif key == "sentinel_nodes":
+            REDIS_CFG[key] = parse_sentinel_nodes(value)
         elif isinstance(value, bool):
             # Convert other booleans to strings for environment compatibility
             REDIS_CFG[key] = "true" if value else "false"
         else:
             # Convert other values to strings
             REDIS_CFG[key] = str(value) if value is not None else None
+
+    if "cluster_mode" in config and "topology" not in config and REDIS_CFG["cluster_mode"]:
+        REDIS_CFG["topology"] = "cluster"
+    elif "cluster_mode" in config and not REDIS_CFG["cluster_mode"] and REDIS_CFG.get(
+        "topology"
+    ) == "cluster":
+        REDIS_CFG["topology"] = "standalone"
+
+    if REDIS_CFG.get("topology") == "cluster":
+        REDIS_CFG["cluster_mode"] = True
+    elif REDIS_CFG.get("topology") in {"standalone", "sentinel"}:
+        REDIS_CFG["cluster_mode"] = False
+
+
+def validate_redis_config(config: dict | None = None) -> tuple[bool, str]:
+    """Validate Redis topology-specific configuration."""
+    config = config or REDIS_CFG
+
+    try:
+        topology = normalize_topology(
+            config.get("topology"),
+            config.get("cluster_mode", False),
+        )
+    except ValueError as exc:
+        return False, str(exc)
+
+    if topology == "sentinel":
+        if not config.get("sentinel_master_name"):
+            return False, "Sentinel topology requires sentinel_master_name"
+        if not parse_sentinel_nodes(config.get("sentinel_nodes")):
+            return False, "Sentinel topology requires at least one sentinel node"
+
+    if topology == "cluster" and config.get("sentinel_master_name"):
+        return False, "Cluster topology cannot be combined with sentinel_master_name"
+
+    return True, ""
 
 
 def set_entraid_config_from_cli(config: dict):

--- a/src/common/connection.py
+++ b/src/common/connection.py
@@ -4,6 +4,7 @@ from typing import Optional, Type, Union
 import redis
 from redis import Redis
 from redis.cluster import RedisCluster
+from redis.sentinel import Sentinel
 
 from src.common.config import REDIS_CFG, is_entraid_auth_enabled
 from src.common.entraid_auth import (
@@ -17,6 +18,46 @@ _logger = logging.getLogger(__name__)
 
 class RedisConnectionManager:
     _instance: Optional[Redis] = None
+
+    @staticmethod
+    def _build_common_connection_params(decode_responses=True) -> dict:
+        connection_params = {
+            "username": REDIS_CFG["username"],
+            "password": REDIS_CFG["password"],
+            "ssl": REDIS_CFG["ssl"],
+            "decode_responses": decode_responses,
+            "lib_name": f"redis-py(mcp-server_v{__version__})",
+        }
+
+        if REDIS_CFG["ssl"]:
+            for key in [
+                "ssl_ca_path",
+                "ssl_keyfile",
+                "ssl_certfile",
+                "ssl_cert_reqs",
+                "ssl_ca_certs",
+            ]:
+                value = REDIS_CFG[key]
+                if value is not None:
+                    connection_params[key] = value
+
+        # Sentinel connections are more strict about unexpected kwargs.
+        return {
+            key: value
+            for key, value in connection_params.items()
+            if value is not None and value != ""
+            or key in {"password", "username", "ssl", "decode_responses", "lib_name"}
+        }
+
+    @staticmethod
+    def _build_sentinel_kwargs() -> dict:
+        sentinel_kwargs = {}
+        if REDIS_CFG["sentinel_username"]:
+            sentinel_kwargs["username"] = REDIS_CFG["sentinel_username"]
+        if REDIS_CFG["sentinel_password"] is not None:
+            sentinel_kwargs["password"] = REDIS_CFG["sentinel_password"]
+
+        return sentinel_kwargs
 
     @classmethod
     def get_connection(cls, decode_responses=True) -> Redis:
@@ -33,57 +74,47 @@ class RedisConnectionManager:
                         )
                         raise
 
-                if REDIS_CFG["cluster_mode"]:
+                connection_params = cls._build_common_connection_params(
+                    decode_responses=decode_responses
+                )
+
+                if credential_provider:
+                    connection_params["credential_provider"] = credential_provider
+                    # Note: Azure Redis Enterprise with EntraID uses plain text connections
+                    # SSL setting is controlled by REDIS_SSL environment variable
+
+                topology = REDIS_CFG["topology"]
+                if topology == "cluster":
                     redis_class: Type[Union[Redis, RedisCluster]] = (
                         redis.cluster.RedisCluster
                     )
-                    connection_params = {
-                        "host": REDIS_CFG["host"],
-                        "port": REDIS_CFG["port"],
-                        "username": REDIS_CFG["username"],
-                        "password": REDIS_CFG["password"],
-                        "ssl": REDIS_CFG["ssl"],
-                        "ssl_ca_path": REDIS_CFG["ssl_ca_path"],
-                        "ssl_keyfile": REDIS_CFG["ssl_keyfile"],
-                        "ssl_certfile": REDIS_CFG["ssl_certfile"],
-                        "ssl_cert_reqs": REDIS_CFG["ssl_cert_reqs"],
-                        "ssl_ca_certs": REDIS_CFG["ssl_ca_certs"],
-                        "decode_responses": decode_responses,
-                        "lib_name": f"redis-py(mcp-server_v{__version__})",
-                        "max_connections_per_node": 10,
-                    }
-
-                    # Add credential provider if available
-                    if credential_provider:
-                        connection_params["credential_provider"] = credential_provider
-                        # Note: Azure Redis Enterprise with EntraID uses plain text connections
-                        # SSL setting is controlled by REDIS_SSL environment variable
+                    cls._instance = redis_class(
+                        host=REDIS_CFG["host"],
+                        port=REDIS_CFG["port"],
+                        max_connections_per_node=10,
+                        **connection_params,
+                    )
+                elif topology == "sentinel":
+                    sentinel_client = Sentinel(
+                        REDIS_CFG["sentinel_nodes"],
+                        sentinel_kwargs=cls._build_sentinel_kwargs(),
+                        db=REDIS_CFG["db"],
+                        max_connections=10,
+                        **connection_params,
+                    )
+                    cls._instance = sentinel_client.master_for(
+                        REDIS_CFG["sentinel_master_name"],
+                        redis_class=redis.Redis,
+                    )
                 else:
-                    redis_class: Type[Union[Redis, RedisCluster]] = redis.Redis
-                    connection_params = {
-                        "host": REDIS_CFG["host"],
-                        "port": REDIS_CFG["port"],
-                        "db": REDIS_CFG["db"],
-                        "username": REDIS_CFG["username"],
-                        "password": REDIS_CFG["password"],
-                        "ssl": REDIS_CFG["ssl"],
-                        "ssl_ca_path": REDIS_CFG["ssl_ca_path"],
-                        "ssl_keyfile": REDIS_CFG["ssl_keyfile"],
-                        "ssl_certfile": REDIS_CFG["ssl_certfile"],
-                        "ssl_cert_reqs": REDIS_CFG["ssl_cert_reqs"],
-                        "ssl_ca_certs": REDIS_CFG["ssl_ca_certs"],
-                        "decode_responses": decode_responses,
-                        "lib_name": f"redis-py(mcp-server_v{__version__})",
-                        "max_connections": 10,
-                    }
-
-                    # Add credential provider if available
-                    if credential_provider:
-                        connection_params["credential_provider"] = credential_provider
-                        # Note: Azure Redis Enterprise with EntraID uses plain text connections
-                        # SSL setting is controlled by REDIS_SSL environment variable
-
-                cls._instance = redis_class(**connection_params)
+                    redis_class = redis.Redis
+                    cls._instance = redis_class(
+                        host=REDIS_CFG["host"],
+                        port=REDIS_CFG["port"],
+                        db=REDIS_CFG["db"],
+                        max_connections=10,
+                        **connection_params,
+                    )
 
             except redis.exceptions.ConnectionError:
                 _logger.error("Failed to connect to Redis server")

--- a/src/main.py
+++ b/src/main.py
@@ -7,20 +7,40 @@ from src.common.config import (
     parse_redis_uri,
     set_redis_config_from_cli,
     set_entraid_config_from_cli,
+    validate_redis_config,
+    DEFAULT_SENTINEL_PORT,
 )
 from src.common.server import mcp
 from src.common.logging_utils import configure_logging
 
 
 class RedisMCPServer:
-    def __init__(self):
-        # Configure logging on server initialization (idempotent)
+    def __init__(self, transport="stdio", http_host="127.0.0.1", http_port=8000):
         configure_logging()
         self._logger = logging.getLogger(__name__)
-        self._logger.info("Starting the Redis MCP Server")
+        self.transport = self._normalize_transport(transport)
+        self.http_host = http_host
+        self.http_port = http_port
+        self._logger.info(
+            "Starting the Redis MCP Server with transport: %s on %s:%s",
+            self.transport,
+            self.http_host,
+            self.http_port,
+        )
+
+    @staticmethod
+    def _normalize_transport(transport):
+        # FastMCP exposes streamable HTTP using the "streamable-http" transport name.
+        # Accept "http" as a user-facing alias because MCP clients and metadata commonly
+        # describe this deployment mode as HTTP.
+        if transport == "http":
+            return "streamable-http"
+        return transport
 
     def run(self):
-        mcp.run()
+        mcp.settings.host = self.http_host
+        mcp.settings.port = self.http_port
+        mcp.run(transport=self.transport)
 
 
 @click.command()
@@ -28,20 +48,83 @@ class RedisMCPServer:
     "--url",
     help="Redis connection URI (redis://user:pass@host:port/db or rediss:// for SSL)",
 )
-@click.option("--host", default="127.0.0.1", help="Redis host")
-@click.option("--port", default=6379, type=int, help="Redis port")
-@click.option("--db", default=0, type=int, help="Redis database number")
-@click.option("--username", help="Redis username")
-@click.option("--password", help="Redis password")
-@click.option("--ssl", is_flag=True, help="Use SSL connection")
-@click.option("--ssl-ca-path", help="Path to CA certificate file")
-@click.option("--ssl-keyfile", help="Path to SSL key file")
-@click.option("--ssl-certfile", help="Path to SSL certificate file")
 @click.option(
-    "--ssl-cert-reqs", default="required", help="SSL certificate requirements"
+    "--transport",
+    type=click.Choice(["stdio", "http", "sse", "streamable-http"]),
+    default="stdio",
+    envvar="TRANSPORT",
+    help="Transport protocol (stdio, http, sse, or streamable-http)",
 )
-@click.option("--ssl-ca-certs", help="Path to CA certificates file")
-@click.option("--cluster-mode", is_flag=True, help="Enable Redis cluster mode")
+@click.option(
+    "--http-port",
+    type=int,
+    default=8000,
+    envvar=["HTTP_PORT", "FASTMCP_PORT"],
+    help="Port for HTTP/SSE transport",
+)
+@click.option(
+    "--http-host",
+    default="127.0.0.1",
+    envvar=["HTTP_HOST", "FASTMCP_HOST"],
+    help="Host for HTTP/SSE transport",
+)
+@click.option("--host", default="127.0.0.1", envvar="REDIS_HOST", help="Redis host")
+@click.option("--port", default=6379, envvar="REDIS_PORT", type=int, help="Redis port")
+@click.option("--db", default=0, envvar="REDIS_DB", type=int, help="Redis database number")
+@click.option("--username", envvar="REDIS_USERNAME", help="Redis username")
+@click.option("--password", envvar="REDIS_PWD", help="Redis password")
+@click.option("--ssl", is_flag=True, envvar="REDIS_SSL", help="Use SSL connection")
+@click.option("--ssl-ca-path", envvar="REDIS_SSL_CA_PATH", help="Path to CA certificate file")
+@click.option("--ssl-keyfile", envvar="REDIS_SSL_KEYFILE", help="Path to SSL key file")
+@click.option("--ssl-certfile", envvar="REDIS_SSL_CERTFILE", help="Path to SSL certificate file")
+@click.option(
+    "--ssl-cert-reqs", default="required", envvar="REDIS_SSL_CERT_REQS", help="SSL certificate requirements"
+)
+@click.option("--ssl-ca-certs", envvar="REDIS_SSL_CA_CERTS", help="Path to CA certificates file")
+@click.option(
+    "--topology",
+    type=click.Choice(["standalone", "sentinel", "cluster"]),
+    envvar="REDIS_TOPOLOGY",
+    help="Redis topology mode",
+)
+@click.option(
+    "--cluster-mode",
+    is_flag=True,
+    envvar="REDIS_CLUSTER_MODE",
+    help="Enable Redis cluster mode (legacy compatibility flag)",
+)
+@click.option(
+    "--sentinel-master-name",
+    envvar="REDIS_SENTINEL_MASTER_NAME",
+    help="Sentinel master name to resolve",
+)
+@click.option(
+    "--sentinel-nodes",
+    envvar="REDIS_SENTINEL_NODES",
+    help="Comma-separated Sentinel nodes in host:port form",
+)
+@click.option(
+    "--sentinel-host",
+    envvar="REDIS_SENTINEL_HOST",
+    help="Single Sentinel host (alternative to --sentinel-nodes)",
+)
+@click.option(
+    "--sentinel-port",
+    envvar="REDIS_SENTINEL_PORT",
+    type=int,
+    default=DEFAULT_SENTINEL_PORT,
+    help="Single Sentinel port when using --sentinel-host",
+)
+@click.option(
+    "--sentinel-username",
+    envvar="REDIS_SENTINEL_USERNAME",
+    help="Sentinel username if Sentinel itself requires authentication",
+)
+@click.option(
+    "--sentinel-password",
+    envvar="REDIS_SENTINEL_PWD",
+    help="Sentinel password if Sentinel itself requires authentication",
+)
 # Entra ID Authentication Options
 @click.option(
     "--entraid-auth-flow",
@@ -90,6 +173,9 @@ class RedisMCPServer:
 )
 def cli(
     url,
+    transport,
+    http_port,
+    http_host,
     host,
     port,
     db,
@@ -101,7 +187,14 @@ def cli(
     ssl_certfile,
     ssl_cert_reqs,
     ssl_ca_certs,
+    topology,
     cluster_mode,
+    sentinel_master_name,
+    sentinel_nodes,
+    sentinel_host,
+    sentinel_port,
+    sentinel_username,
+    sentinel_password,
     entraid_auth_flow,
     entraid_client_id,
     entraid_client_secret,
@@ -132,9 +225,17 @@ def cli(
             "port": port,
             "db": db,
             "ssl": ssl,
+            "topology": topology,
             "cluster_mode": cluster_mode,
+            "sentinel_master_name": sentinel_master_name,
+            "sentinel_username": sentinel_username,
+            "sentinel_password": sentinel_password,
         }
 
+        if sentinel_nodes:
+            config["sentinel_nodes"] = sentinel_nodes
+        elif sentinel_host:
+            config["sentinel_nodes"] = [(sentinel_host, sentinel_port)]
         if username:
             config["username"] = username
         if password:
@@ -151,6 +252,11 @@ def cli(
             config["ssl_ca_certs"] = ssl_ca_certs
 
         set_redis_config_from_cli(config)
+
+    is_valid, error_message = validate_redis_config()
+    if not is_valid:
+        click.echo(f"Error validating Redis configuration: {error_message}", err=True)
+        sys.exit(1)
 
     # Handle Entra ID authentication configuration
     entraid_config = {}
@@ -187,13 +293,17 @@ def cli(
         set_entraid_config_from_cli(entraid_config)
 
     # Start the server
-    server = RedisMCPServer()
+    server = RedisMCPServer(
+        transport=transport,
+        http_host=http_host,
+        http_port=http_port,
+    )
     server.run()
 
 
 def main():
     """Legacy main function for backward compatibility."""
-    server = RedisMCPServer()
+    server = RedisMCPServer(transport="stdio")
     server.run()
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -70,17 +70,28 @@ class RedisMCPServer:
 )
 @click.option("--host", default="127.0.0.1", envvar="REDIS_HOST", help="Redis host")
 @click.option("--port", default=6379, envvar="REDIS_PORT", type=int, help="Redis port")
-@click.option("--db", default=0, envvar="REDIS_DB", type=int, help="Redis database number")
+@click.option(
+    "--db", default=0, envvar="REDIS_DB", type=int, help="Redis database number"
+)
 @click.option("--username", envvar="REDIS_USERNAME", help="Redis username")
 @click.option("--password", envvar="REDIS_PWD", help="Redis password")
 @click.option("--ssl", is_flag=True, envvar="REDIS_SSL", help="Use SSL connection")
-@click.option("--ssl-ca-path", envvar="REDIS_SSL_CA_PATH", help="Path to CA certificate file")
-@click.option("--ssl-keyfile", envvar="REDIS_SSL_KEYFILE", help="Path to SSL key file")
-@click.option("--ssl-certfile", envvar="REDIS_SSL_CERTFILE", help="Path to SSL certificate file")
 @click.option(
-    "--ssl-cert-reqs", default="required", envvar="REDIS_SSL_CERT_REQS", help="SSL certificate requirements"
+    "--ssl-ca-path", envvar="REDIS_SSL_CA_PATH", help="Path to CA certificate file"
 )
-@click.option("--ssl-ca-certs", envvar="REDIS_SSL_CA_CERTS", help="Path to CA certificates file")
+@click.option("--ssl-keyfile", envvar="REDIS_SSL_KEYFILE", help="Path to SSL key file")
+@click.option(
+    "--ssl-certfile", envvar="REDIS_SSL_CERTFILE", help="Path to SSL certificate file"
+)
+@click.option(
+    "--ssl-cert-reqs",
+    default="required",
+    envvar="REDIS_SSL_CERT_REQS",
+    help="SSL certificate requirements",
+)
+@click.option(
+    "--ssl-ca-certs", envvar="REDIS_SSL_CA_CERTS", help="Path to CA certificates file"
+)
 @click.option(
     "--topology",
     type=click.Choice(["standalone", "sentinel", "cluster"]),
@@ -225,12 +236,17 @@ def cli(
             "port": port,
             "db": db,
             "ssl": ssl,
-            "topology": topology,
             "cluster_mode": cluster_mode,
             "sentinel_master_name": sentinel_master_name,
             "sentinel_username": sentinel_username,
             "sentinel_password": sentinel_password,
         }
+
+        # Only include topology in config when explicitly set, so the after-loop
+        # guard in set_redis_config_from_cli can properly handle --cluster-mode
+        # without --topology
+        if topology is not None:
+            config["topology"] = topology
 
         if sentinel_nodes:
             config["sentinel_nodes"] = sentinel_nodes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 import pytest
 import redis
 from redis.exceptions import ConnectionError, RedisError, TimeoutError
+from redis.sentinel import Sentinel
 
 
 @pytest.fixture
@@ -20,6 +21,13 @@ def mock_redis():
 def mock_redis_cluster():
     """Create a mock Redis Cluster connection."""
     mock = Mock(spec=redis.cluster.RedisCluster)
+    return mock
+
+
+@pytest.fixture
+def mock_redis_sentinel():
+    """Create a mock Redis Sentinel client."""
+    mock = Mock(spec=Sentinel)
     return mock
 
 
@@ -50,6 +58,11 @@ def redis_config():
         "ssl_cert_reqs": "required",
         "ssl_ca_certs": None,
         "cluster_mode": False,
+        "topology": "standalone",
+        "sentinel_master_name": None,
+        "sentinel_nodes": [],
+        "sentinel_username": None,
+        "sentinel_password": None,
     }
 
 
@@ -62,6 +75,8 @@ def redis_uri_samples():
         "ssl": "rediss://user:pass@localhost:6379/0",
         "with_query": "redis://localhost:6379/0?ssl_cert_reqs=required",
         "cluster": "redis://localhost:6379/0?cluster_mode=true",
+        "cluster_topology": "redis://localhost:6379/0?topology=cluster",
+        "sentinel": "redis://localhost:6379/0?topology=sentinel&sentinel_master_name=mymaster&sentinel_nodes=host1:26379,host2:26380",
     }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,12 @@ from unittest.mock import patch
 
 import pytest
 
-from src.common.config import REDIS_CFG, parse_redis_uri, set_redis_config_from_cli
+from src.common.config import (
+    REDIS_CFG,
+    parse_redis_uri,
+    set_redis_config_from_cli,
+    validate_redis_config,
+)
 
 
 class TestParseRedisURI:
@@ -18,7 +23,14 @@ class TestParseRedisURI:
         uri = "redis://localhost:6379/0"
         result = parse_redis_uri(uri)
 
-        expected = {"ssl": False, "host": "localhost", "port": 6379, "db": 0}
+        expected = {
+            "ssl": False,
+            "host": "localhost",
+            "port": 6379,
+            "db": 0,
+            "topology": "standalone",
+            "cluster_mode": False,
+        }
         assert result == expected
 
     def test_parse_redis_uri_with_auth(self):
@@ -31,6 +43,8 @@ class TestParseRedisURI:
             "host": "localhost",
             "port": 6379,
             "db": 1,
+            "topology": "standalone",
+            "cluster_mode": False,
             "username": "user",
             "password": "pass",
         }
@@ -46,6 +60,8 @@ class TestParseRedisURI:
             "host": "redis.example.com",
             "port": 6380,
             "db": 2,
+            "topology": "standalone",
+            "cluster_mode": False,
             "username": "user",
             "password": "pass",
         }
@@ -125,6 +141,36 @@ class TestParseRedisURI:
         with pytest.raises(ValueError, match="Unsupported scheme: http"):
             parse_redis_uri(uri)
 
+    def test_parse_uri_with_topology_cluster(self):
+        """Cluster topology should be parsed from query params."""
+        uri = "redis://localhost:6379/0?topology=cluster"
+        result = parse_redis_uri(uri)
+
+        assert result["topology"] == "cluster"
+        assert result["cluster_mode"] is True
+
+    def test_parse_uri_with_legacy_cluster_mode(self):
+        """Legacy cluster_mode query param should still work."""
+        uri = "redis://localhost:6379/0?cluster_mode=true"
+        result = parse_redis_uri(uri)
+
+        assert result["topology"] == "cluster"
+        assert result["cluster_mode"] is True
+
+    def test_parse_uri_with_sentinel_configuration(self):
+        """Sentinel query params should be parsed."""
+        uri = (
+            "redis://localhost:6379/0?"
+            "topology=sentinel&sentinel_master_name=mymaster&"
+            "sentinel_nodes=host1:26379,host2:26380"
+        )
+        result = parse_redis_uri(uri)
+
+        assert result["topology"] == "sentinel"
+        assert result["cluster_mode"] is False
+        assert result["sentinel_master_name"] == "mymaster"
+        assert result["sentinel_nodes"] == [("host1", 26379), ("host2", 26380)]
+
 
 class TestSetRedisConfigFromCLI:
     """Test cases for set_redis_config_from_cli function."""
@@ -166,7 +212,7 @@ class TestSetRedisConfigFromCLI:
 
     def test_set_boolean_values(self):
         """Test setting boolean configuration values."""
-        config = {"ssl": True, "cluster_mode": False}
+        config = {"ssl": True, "cluster_mode": False, "topology": "standalone"}
 
         set_redis_config_from_cli(config)
 
@@ -174,6 +220,7 @@ class TestSetRedisConfigFromCLI:
         assert isinstance(REDIS_CFG["ssl"], bool)
         assert REDIS_CFG["cluster_mode"] is False
         assert isinstance(REDIS_CFG["cluster_mode"], bool)
+        assert REDIS_CFG["topology"] == "standalone"
 
     def test_set_none_values(self):
         """Test setting None configuration values."""
@@ -192,6 +239,7 @@ class TestSetRedisConfigFromCLI:
             "ssl": True,
             "ssl_ca_path": "/path/to/ca.pem",
             "cluster_mode": False,
+            "topology": "standalone",
             "username": None,
         }
 
@@ -202,6 +250,7 @@ class TestSetRedisConfigFromCLI:
         assert REDIS_CFG["ssl"] is True
         assert REDIS_CFG["ssl_ca_path"] == "/path/to/ca.pem"
         assert REDIS_CFG["cluster_mode"] is False
+        assert REDIS_CFG["topology"] == "standalone"
         assert REDIS_CFG["username"] is None
 
     def test_convert_string_integers(self):
@@ -225,6 +274,69 @@ class TestSetRedisConfigFromCLI:
 
         # This would be converted to string for environment compatibility
         assert REDIS_CFG["some_other_bool"] == "true"
+
+    def test_set_topology_to_cluster_sets_legacy_flag(self):
+        """Topology updates should keep cluster_mode in sync."""
+        set_redis_config_from_cli({"topology": "cluster"})
+
+        assert REDIS_CFG["topology"] == "cluster"
+        assert REDIS_CFG["cluster_mode"] is True
+
+    def test_set_sentinel_nodes_parses_string(self):
+        """Sentinel nodes should be normalized into host/port tuples."""
+        set_redis_config_from_cli(
+            {
+                "topology": "sentinel",
+                "sentinel_nodes": "host1:26379,host2:26380",
+                "sentinel_master_name": "mymaster",
+            }
+        )
+
+        assert REDIS_CFG["topology"] == "sentinel"
+        assert REDIS_CFG["cluster_mode"] is False
+        assert REDIS_CFG["sentinel_nodes"] == [("host1", 26379), ("host2", 26380)]
+
+    def test_validate_sentinel_requires_master_name(self):
+        """Sentinel config must provide a master name."""
+        is_valid, error_message = validate_redis_config(
+            {
+                "topology": "sentinel",
+                "cluster_mode": False,
+                "sentinel_nodes": [("host1", 26379)],
+                "sentinel_master_name": None,
+            }
+        )
+
+        assert is_valid is False
+        assert "sentinel_master_name" in error_message
+
+    def test_validate_sentinel_requires_nodes(self):
+        """Sentinel config must provide at least one node."""
+        is_valid, error_message = validate_redis_config(
+            {
+                "topology": "sentinel",
+                "cluster_mode": False,
+                "sentinel_nodes": [],
+                "sentinel_master_name": "mymaster",
+            }
+        )
+
+        assert is_valid is False
+        assert "sentinel node" in error_message
+
+    def test_validate_conflicting_cluster_and_sentinel(self):
+        """Cluster topology should not accept sentinel-only settings."""
+        is_valid, error_message = validate_redis_config(
+            {
+                "topology": "cluster",
+                "cluster_mode": True,
+                "sentinel_master_name": "mymaster",
+                "sentinel_nodes": [("host1", 26379)],
+            }
+        )
+
+        assert is_valid is False
+        assert "cannot be combined" in error_message
 
     def test_empty_config(self):
         """Test setting empty configuration."""
@@ -259,7 +371,10 @@ class TestRedisConfigDefaults:
         assert config["password"] == ""
         assert config["ssl"] is False
         assert config["cluster_mode"] is False
+        assert config["topology"] == "standalone"
         assert config["db"] == 0
+        assert config["sentinel_master_name"] is None
+        assert config["sentinel_nodes"] == []
 
     @patch.dict(
         os.environ,
@@ -286,3 +401,28 @@ class TestRedisConfigDefaults:
         assert config["port"] == 6380
         assert config["ssl"] is True
         assert config["cluster_mode"] is True
+        assert config["topology"] == "cluster"
+
+    @patch.dict(
+        os.environ,
+        {
+            "REDIS_TOPOLOGY": "sentinel",
+            "REDIS_SENTINEL_MASTER_NAME": "mymaster",
+            "REDIS_SENTINEL_NODES": "host1:26379,host2:26380",
+        },
+    )
+    @patch("src.common.config.load_dotenv")
+    def test_sentinel_config_from_environment(self, mock_load_dotenv):
+        """Sentinel configuration should load from environment variables."""
+        import importlib
+
+        import src.common.config
+
+        importlib.reload(src.common.config)
+
+        config = src.common.config.REDIS_CFG
+
+        assert config["topology"] == "sentinel"
+        assert config["cluster_mode"] is False
+        assert config["sentinel_master_name"] == "mymaster"
+        assert config["sentinel_nodes"] == [("host1", 26379), ("host2", 26380)]

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -5,43 +5,49 @@ Unit tests for src/common/connection.py
 from unittest.mock import Mock, patch
 
 import pytest
+import redis
 from redis.exceptions import ConnectionError
 
 from src.common.connection import RedisConnectionManager
+
+
+def make_config(**overrides):
+    config = {
+        "topology": "standalone",
+        "cluster_mode": False,
+        "host": "localhost",
+        "port": 6379,
+        "db": 0,
+        "username": None,
+        "password": "",
+        "ssl": False,
+        "ssl_ca_path": None,
+        "ssl_keyfile": None,
+        "ssl_certfile": None,
+        "ssl_cert_reqs": "required",
+        "ssl_ca_certs": None,
+        "sentinel_master_name": None,
+        "sentinel_nodes": [],
+        "sentinel_username": None,
+        "sentinel_password": None,
+    }
+    config.update(overrides)
+    return config
 
 
 class TestRedisConnectionManager:
     """Test cases for RedisConnectionManager class."""
 
     def setup_method(self):
-        """Set up test fixtures."""
-        # Reset singleton instance before each test
         RedisConnectionManager._instance = None
 
     def teardown_method(self):
-        """Clean up after each test."""
-        # Reset singleton instance after each test
         RedisConnectionManager._instance = None
 
     @patch("src.common.connection.redis.Redis")
-    @patch("src.common.connection.REDIS_CFG")
+    @patch("src.common.connection.REDIS_CFG", new_callable=lambda: make_config())
     def test_get_connection_standalone_mode(self, mock_config, mock_redis_class):
         """Test getting connection in standalone mode."""
-        mock_config.__getitem__.side_effect = lambda key: {
-            "cluster_mode": False,
-            "host": "localhost",
-            "port": 6379,
-            "db": 0,
-            "username": None,
-            "password": "",
-            "ssl": False,
-            "ssl_ca_path": None,
-            "ssl_keyfile": None,
-            "ssl_certfile": None,
-            "ssl_cert_reqs": "required",
-            "ssl_ca_certs": None,
-        }[key]
-
         mock_redis_instance = Mock()
         mock_redis_class.return_value = mock_redis_instance
 
@@ -50,7 +56,6 @@ class TestRedisConnectionManager:
         assert connection == mock_redis_instance
         mock_redis_class.assert_called_once()
 
-        # Verify connection parameters
         call_args = mock_redis_class.call_args[1]
         assert call_args["host"] == "localhost"
         assert call_args["port"] == 6379
@@ -60,23 +65,22 @@ class TestRedisConnectionManager:
         assert "lib_name" in call_args
 
     @patch("src.common.connection.redis.cluster.RedisCluster")
-    @patch("src.common.connection.REDIS_CFG")
+    @patch(
+        "src.common.connection.REDIS_CFG",
+        new_callable=lambda: make_config(
+            topology="cluster",
+            cluster_mode=True,
+            username="testuser",
+            password="testpass",
+            ssl=True,
+            ssl_ca_path="/path/to/ca.pem",
+            ssl_keyfile="/path/to/key.pem",
+            ssl_certfile="/path/to/cert.pem",
+            ssl_ca_certs="/path/to/ca-bundle.pem",
+        ),
+    )
     def test_get_connection_cluster_mode(self, mock_config, mock_cluster_class):
         """Test getting connection in cluster mode."""
-        mock_config.__getitem__.side_effect = lambda key: {
-            "cluster_mode": True,
-            "host": "localhost",
-            "port": 6379,
-            "username": "testuser",
-            "password": "testpass",
-            "ssl": True,
-            "ssl_ca_path": "/path/to/ca.pem",
-            "ssl_keyfile": "/path/to/key.pem",
-            "ssl_certfile": "/path/to/cert.pem",
-            "ssl_cert_reqs": "required",
-            "ssl_ca_certs": "/path/to/ca-bundle.pem",
-        }[key]
-
         mock_cluster_instance = Mock()
         mock_cluster_class.return_value = mock_cluster_instance
 
@@ -85,7 +89,6 @@ class TestRedisConnectionManager:
         assert connection == mock_cluster_instance
         mock_cluster_class.assert_called_once()
 
-        # Verify connection parameters
         call_args = mock_cluster_class.call_args[1]
         assert call_args["host"] == "localhost"
         assert call_args["port"] == 6379
@@ -97,59 +100,65 @@ class TestRedisConnectionManager:
         assert call_args["max_connections_per_node"] == 10
         assert "lib_name" in call_args
 
-    @patch("src.common.connection.redis.Redis")
-    @patch("src.common.connection.REDIS_CFG")
-    def test_get_connection_singleton_behavior(self, mock_config, mock_redis_class):
-        """Test that get_connection returns the same instance (singleton behavior)."""
-        mock_config.__getitem__.side_effect = lambda key: {
-            "cluster_mode": False,
-            "host": "localhost",
-            "port": 6379,
-            "db": 0,
-            "username": None,
-            "password": "",
-            "ssl": False,
-            "ssl_ca_path": None,
-            "ssl_keyfile": None,
-            "ssl_certfile": None,
-            "ssl_cert_reqs": "required",
-            "ssl_ca_certs": None,
-        }[key]
+    @patch("src.common.connection.Sentinel")
+    @patch(
+        "src.common.connection.REDIS_CFG",
+        new_callable=lambda: make_config(
+            topology="sentinel",
+            sentinel_master_name="mymaster",
+            sentinel_nodes=[("host1", 26379), ("host2", 26380)],
+            username="redis-user",
+            password="redis-pass",
+            sentinel_username="sentinel-user",
+            sentinel_password="sentinel-pass",
+            ssl=True,
+        ),
+    )
+    def test_get_connection_sentinel_mode(self, mock_config, mock_sentinel_class):
+        """Sentinel mode should resolve a master connection."""
+        mock_master_connection = Mock()
+        mock_sentinel_instance = Mock()
+        mock_sentinel_instance.master_for.return_value = mock_master_connection
+        mock_sentinel_class.return_value = mock_sentinel_instance
 
+        connection = RedisConnectionManager.get_connection()
+
+        assert connection == mock_master_connection
+        mock_sentinel_class.assert_called_once()
+        sentinel_call = mock_sentinel_class.call_args
+        assert sentinel_call.args[0] == [("host1", 26379), ("host2", 26380)]
+        assert sentinel_call.kwargs["sentinel_kwargs"] == {
+            "username": "sentinel-user",
+            "password": "sentinel-pass",
+        }
+        assert sentinel_call.kwargs["username"] == "redis-user"
+        assert sentinel_call.kwargs["password"] == "redis-pass"
+        assert sentinel_call.kwargs["ssl"] is True
+        assert sentinel_call.kwargs["db"] == 0
+        mock_sentinel_instance.master_for.assert_called_once_with(
+            "mymaster",
+            redis_class=redis.Redis,
+        )
+
+    @patch("src.common.connection.redis.Redis")
+    @patch("src.common.connection.REDIS_CFG", new_callable=lambda: make_config())
+    def test_get_connection_singleton_behavior(self, mock_config, mock_redis_class):
+        """Test that get_connection returns the same instance."""
         mock_redis_instance = Mock()
         mock_redis_class.return_value = mock_redis_instance
 
-        # First call
         connection1 = RedisConnectionManager.get_connection()
-        # Second call
         connection2 = RedisConnectionManager.get_connection()
 
         assert connection1 == connection2
-        assert connection1 == mock_redis_instance
-        # Redis class should only be called once
         mock_redis_class.assert_called_once()
 
     @patch("src.common.connection.redis.Redis")
-    @patch("src.common.connection.REDIS_CFG")
+    @patch("src.common.connection.REDIS_CFG", new_callable=lambda: make_config())
     def test_get_connection_with_decode_responses_false(
         self, mock_config, mock_redis_class
     ):
         """Test getting connection with decode_responses=False."""
-        mock_config.__getitem__.side_effect = lambda key: {
-            "cluster_mode": False,
-            "host": "localhost",
-            "port": 6379,
-            "db": 0,
-            "username": None,
-            "password": "",
-            "ssl": False,
-            "ssl_ca_path": None,
-            "ssl_keyfile": None,
-            "ssl_certfile": None,
-            "ssl_cert_reqs": "required",
-            "ssl_ca_certs": None,
-        }[key]
-
         mock_redis_instance = Mock()
         mock_redis_class.return_value = mock_redis_instance
 
@@ -159,162 +168,50 @@ class TestRedisConnectionManager:
         call_args = mock_redis_class.call_args[1]
         assert call_args["decode_responses"] is False
 
-    @patch("src.common.connection.redis.Redis")
-    @patch("src.common.connection.REDIS_CFG")
-    def test_get_connection_with_ssl_configuration(self, mock_config, mock_redis_class):
-        """Test getting connection with SSL configuration."""
-        mock_config.__getitem__.side_effect = lambda key: {
-            "cluster_mode": False,
-            "host": "redis.example.com",
-            "port": 6380,
-            "db": 1,
-            "username": "ssluser",
-            "password": "sslpass",
-            "ssl": True,
-            "ssl_ca_path": "/path/to/ca.pem",
-            "ssl_keyfile": "/path/to/key.pem",
-            "ssl_certfile": "/path/to/cert.pem",
-            "ssl_cert_reqs": "optional",
-            "ssl_ca_certs": "/path/to/ca-bundle.pem",
-        }[key]
-
-        mock_redis_instance = Mock()
-        mock_redis_class.return_value = mock_redis_instance
-
-        connection = RedisConnectionManager.get_connection()
-        assert connection == mock_redis_instance
-
-        call_args = mock_redis_class.call_args[1]
-        assert call_args["ssl"] is True
-        assert call_args["ssl_ca_path"] == "/path/to/ca.pem"
-        assert call_args["ssl_keyfile"] == "/path/to/key.pem"
-        assert call_args["ssl_certfile"] == "/path/to/cert.pem"
-        assert call_args["ssl_cert_reqs"] == "optional"
-        assert call_args["ssl_ca_certs"] == "/path/to/ca-bundle.pem"
-
-    @patch("src.common.connection.redis.Redis")
-    @patch("src.common.connection.REDIS_CFG")
-    def test_get_connection_includes_version_in_lib_name(
-        self, mock_config, mock_redis_class
-    ):
-        """Test that connection includes version information in lib_name."""
-        mock_config.__getitem__.side_effect = lambda key: {
-            "cluster_mode": False,
-            "host": "localhost",
-            "port": 6379,
-            "db": 0,
-            "username": None,
-            "password": "",
-            "ssl": False,
-            "ssl_ca_path": None,
-            "ssl_keyfile": None,
-            "ssl_certfile": None,
-            "ssl_cert_reqs": "required",
-            "ssl_ca_certs": None,
-        }[key]
-
-        mock_redis_instance = Mock()
-        mock_redis_class.return_value = mock_redis_instance
-
-        with patch("src.common.connection.__version__", "1.0.0"):
-            connection = RedisConnectionManager.get_connection()
-
-            assert connection == mock_redis_instance
-
-            call_args = mock_redis_class.call_args[1]
-            assert "redis-py(mcp-server_v1.0.0)" in call_args["lib_name"]
-
-    @patch("src.common.connection.redis.Redis")
-    @patch("src.common.connection.REDIS_CFG")
+    @patch(
+        "src.common.connection.redis.Redis",
+        side_effect=ConnectionError("Connection refused"),
+    )
+    @patch("src.common.connection.REDIS_CFG", new_callable=lambda: make_config())
     def test_connection_error_handling(self, mock_config, mock_redis_class):
-        """Test connection error handling."""
-        mock_config.__getitem__.side_effect = lambda key: {
-            "cluster_mode": False,
-            "host": "localhost",
-            "port": 6379,
-            "db": 0,
-            "username": None,
-            "password": "",
-            "ssl": False,
-            "ssl_ca_path": None,
-            "ssl_keyfile": None,
-            "ssl_certfile": None,
-            "ssl_cert_reqs": "required",
-            "ssl_ca_certs": None,
-        }[key]
-
-        # Mock Redis constructor to raise ConnectionError
-        mock_redis_class.side_effect = ConnectionError("Connection refused")
-
+        """Test standalone connection error handling."""
         with pytest.raises(ConnectionError, match="Connection refused"):
             RedisConnectionManager.get_connection()
 
-    @patch("src.common.connection.redis.cluster.RedisCluster")
-    @patch("src.common.connection.REDIS_CFG")
+    @patch(
+        "src.common.connection.redis.cluster.RedisCluster",
+        side_effect=ConnectionError("Cluster connection failed"),
+    )
+    @patch(
+        "src.common.connection.REDIS_CFG",
+        new_callable=lambda: make_config(topology="cluster", cluster_mode=True),
+    )
     def test_cluster_connection_error_handling(self, mock_config, mock_cluster_class):
         """Test cluster connection error handling."""
-        mock_config.__getitem__.side_effect = lambda key: {
-            "cluster_mode": True,
-            "host": "localhost",
-            "port": 6379,
-            "username": None,
-            "password": "",
-            "ssl": False,
-            "ssl_ca_path": None,
-            "ssl_keyfile": None,
-            "ssl_certfile": None,
-            "ssl_cert_reqs": "required",
-            "ssl_ca_certs": None,
-        }[key]
-
-        # Mock RedisCluster constructor to raise ConnectionError
-        mock_cluster_class.side_effect = ConnectionError("Cluster connection failed")
-
         with pytest.raises(ConnectionError, match="Cluster connection failed"):
+            RedisConnectionManager.get_connection()
+
+    @patch("src.common.connection.Sentinel", side_effect=ConnectionError("Sentinel failed"))
+    @patch(
+        "src.common.connection.REDIS_CFG",
+        new_callable=lambda: make_config(
+            topology="sentinel",
+            sentinel_master_name="mymaster",
+            sentinel_nodes=[("host1", 26379)],
+        ),
+    )
+    def test_sentinel_connection_error_handling(self, mock_config, mock_sentinel_class):
+        """Test sentinel connection error handling."""
+        with pytest.raises(ConnectionError, match="Sentinel failed"):
             RedisConnectionManager.get_connection()
 
     def test_reset_instance(self):
         """Test that the singleton instance can be reset."""
-        # Set up a mock instance
         mock_instance = Mock()
         RedisConnectionManager._instance = mock_instance
 
-        # Verify instance is set
         assert RedisConnectionManager._instance == mock_instance
 
-        # Reset instance
         RedisConnectionManager._instance = None
 
-        # Verify instance is reset
         assert RedisConnectionManager._instance is None
-
-    @patch("src.common.connection.redis.Redis")
-    @patch("src.common.connection.REDIS_CFG")
-    def test_connection_parameters_filtering(self, mock_config, mock_redis_class):
-        """Test that None values are properly handled in connection parameters."""
-        mock_config.__getitem__.side_effect = lambda key: {
-            "cluster_mode": False,
-            "host": "localhost",
-            "port": 6379,
-            "db": 0,
-            "username": None,  # This should be passed as None
-            "password": "",  # This should be passed as empty string
-            "ssl": False,
-            "ssl_ca_path": None,
-            "ssl_keyfile": None,
-            "ssl_certfile": None,
-            "ssl_cert_reqs": "required",
-            "ssl_ca_certs": None,
-        }[key]
-
-        mock_redis_instance = Mock()
-        mock_redis_class.return_value = mock_redis_instance
-
-        connection = RedisConnectionManager.get_connection()
-
-        assert connection == mock_redis_instance
-
-        call_args = mock_redis_class.call_args[1]
-        assert call_args["username"] is None
-        assert call_args["password"] == ""
-        assert call_args["ssl_ca_path"] is None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -141,7 +141,9 @@ class TestCLI:
         assert call_args["username"] == "testuser"
         assert call_args["password"] == "testpass"
         assert call_args["ssl"] is True
-        assert call_args["topology"] is None
+        # topology should not be in config when --topology is not explicitly passed,
+        # allowing it to be determined from environment or defaults
+        assert "topology" not in call_args
 
     @patch("src.main.set_redis_config_from_cli")
     @patch("src.main.RedisMCPServer")
@@ -188,7 +190,9 @@ class TestCLI:
         assert result.exit_code == 0
         call_args = mock_set_config.call_args[0][0]
         assert call_args["cluster_mode"] is True
-        assert call_args["topology"] is None
+        # topology should NOT be in config when --cluster-mode is passed without
+        # --topology, so the after-loop guard can properly set it to "cluster"
+        assert "topology" not in call_args
 
     @patch("src.main.set_redis_config_from_cli")
     @patch("src.main.RedisMCPServer")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,6 +39,24 @@ class TestRedisMCPServer:
         mock_mcp_run.assert_called_once()
 
     @patch("src.main.mcp.run")
+    def test_run_sets_http_host_port_and_normalizes_http_transport(self, mock_mcp_run):
+        """HTTP settings should be applied before starting FastMCP."""
+        server = RedisMCPServer(
+            transport="http",
+            http_host="0.0.0.0",
+            http_port=9000,
+        )
+
+        server.run()
+
+        assert server.transport == "streamable-http"
+        assert server.http_host == "0.0.0.0"
+        assert server.http_port == 9000
+        assert server._normalize_transport("http") == "streamable-http"
+        assert server._normalize_transport("sse") == "sse"
+        mock_mcp_run.assert_called_once_with(transport="streamable-http")
+
+    @patch("src.main.mcp.run")
     def test_run_propagates_exceptions(self, mock_mcp_run):
         """Test that exceptions from mcp.run() are propagated."""
         mock_mcp_run.side_effect = Exception("MCP run failed")
@@ -62,7 +80,12 @@ class TestCLI:
         self, mock_server_class, mock_set_config, mock_parse_uri
     ):
         """Test CLI with --url parameter."""
-        mock_parse_uri.return_value = {"host": "localhost", "port": 6379}
+        mock_parse_uri.return_value = {
+            "host": "localhost",
+            "port": 6379,
+            "topology": "standalone",
+            "cluster_mode": False,
+        }
         mock_server = Mock()
         mock_server_class.return_value = mock_server
 
@@ -70,8 +93,17 @@ class TestCLI:
 
         assert result.exit_code == 0
         mock_parse_uri.assert_called_once_with("redis://localhost:6379/0")
-        mock_set_config.assert_called_once_with({"host": "localhost", "port": 6379})
-        mock_server_class.assert_called_once()
+        mock_set_config.assert_called_once_with(
+            {
+                "host": "localhost",
+                "port": 6379,
+                "topology": "standalone",
+                "cluster_mode": False,
+            }
+        )
+        mock_server_class.assert_called_once_with(
+            transport="stdio", http_host="127.0.0.1", http_port=8000
+        )
         mock_server.run.assert_called_once()
 
     @patch("src.main.set_redis_config_from_cli")
@@ -109,6 +141,7 @@ class TestCLI:
         assert call_args["username"] == "testuser"
         assert call_args["password"] == "testpass"
         assert call_args["ssl"] is True
+        assert call_args["topology"] is None
 
     @patch("src.main.set_redis_config_from_cli")
     @patch("src.main.RedisMCPServer")
@@ -155,6 +188,47 @@ class TestCLI:
         assert result.exit_code == 0
         call_args = mock_set_config.call_args[0][0]
         assert call_args["cluster_mode"] is True
+        assert call_args["topology"] is None
+
+    @patch("src.main.set_redis_config_from_cli")
+    @patch("src.main.RedisMCPServer")
+    def test_cli_with_sentinel_topology(self, mock_server_class, mock_set_config):
+        """Test CLI sentinel topology parameters."""
+        mock_server = Mock()
+        mock_server_class.return_value = mock_server
+
+        result = self.runner.invoke(
+            cli,
+            [
+                "--topology",
+                "sentinel",
+                "--sentinel-master-name",
+                "mymaster",
+                "--sentinel-nodes",
+                "host1:26379,host2:26380",
+            ],
+        )
+
+        assert result.exit_code == 0
+        call_args = mock_set_config.call_args[0][0]
+        assert call_args["topology"] == "sentinel"
+        assert call_args["sentinel_master_name"] == "mymaster"
+        assert call_args["sentinel_nodes"] == "host1:26379,host2:26380"
+
+    @patch("src.main.parse_redis_uri")
+    def test_cli_with_invalid_sentinel_config(self, mock_parse_uri):
+        """Sentinel topology should require master name and nodes."""
+        mock_parse_uri.return_value = {
+            "host": "localhost",
+            "port": 6379,
+            "topology": "standalone",
+            "cluster_mode": False,
+        }
+
+        result = self.runner.invoke(cli, ["--topology", "sentinel"])
+
+        assert result.exit_code != 0
+        assert "Error validating Redis configuration" in result.output
 
     @patch("src.main.parse_redis_uri")
     def test_cli_with_invalid_url(self, mock_parse_uri):
@@ -213,8 +287,7 @@ class TestCLI:
         # Check that only non-None values are in the config
         for key, value in call_args.items():
             if value is not None:
-                # These should be the default values or explicitly set values
-                assert isinstance(value, (str, int, bool))
+                assert isinstance(value, (str, int, bool, list))
 
     @patch("src.main.parse_redis_uri")
     @patch("src.main.set_redis_config_from_cli")
@@ -223,7 +296,12 @@ class TestCLI:
         self, mock_server_class, mock_set_config, mock_parse_uri
     ):
         """Test that --url parameter takes precedence over individual parameters."""
-        mock_parse_uri.return_value = {"host": "uri-host", "port": 9999}
+        mock_parse_uri.return_value = {
+            "host": "uri-host",
+            "port": 9999,
+            "topology": "cluster",
+            "cluster_mode": True,
+        }
         mock_server = Mock()
         mock_server_class.return_value = mock_server
 
@@ -245,3 +323,208 @@ class TestCLI:
         call_args = mock_set_config.call_args[0][0]
         assert call_args["host"] == "uri-host"
         assert call_args["port"] == 9999
+        assert call_args["topology"] == "cluster"
+        assert call_args["cluster_mode"] is True
+
+
+class TestTransportProtocols:
+    """Test cases for different transport protocols."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.runner = CliRunner()
+
+    @patch("src.main.set_redis_config_from_cli")
+    @patch("src.main.RedisMCPServer")
+    def test_http_transport_with_custom_host_port(
+        self, mock_server_class, mock_set_config
+    ):
+        """Test HTTP transport with custom host and port."""
+        mock_server = Mock()
+        mock_server_class.return_value = mock_server
+
+        result = self.runner.invoke(
+            cli,
+            [
+                "--transport",
+                "http",
+                "--http-host",
+                "0.0.0.0",
+                "--http-port",
+                "9000",
+                "--url",
+                "redis://localhost:6379/0",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_server_class.assert_called_once_with(
+            transport="http", http_host="0.0.0.0", http_port=9000
+        )
+        mock_server.run.assert_called_once()
+
+    @patch("src.main.set_redis_config_from_cli")
+    @patch("src.main.RedisMCPServer")
+    def test_sse_transport_with_default_host_port(
+        self, mock_server_class, mock_set_config
+    ):
+        """Test SSE transport with default host and port."""
+        mock_server = Mock()
+        mock_server_class.return_value = mock_server
+
+        result = self.runner.invoke(
+            cli,
+            ["--transport", "sse", "--url", "redis://localhost:6379/0"],
+        )
+
+        assert result.exit_code == 0
+        mock_server_class.assert_called_once_with(
+            transport="sse", http_host="127.0.0.1", http_port=8000
+        )
+        mock_server.run.assert_called_once()
+
+    @patch("src.main.set_redis_config_from_cli")
+    @patch("src.main.RedisMCPServer")
+    def test_streamable_http_transport(self, mock_server_class, mock_set_config):
+        """Test streamable-http transport."""
+        mock_server = Mock()
+        mock_server_class.return_value = mock_server
+
+        result = self.runner.invoke(
+            cli,
+            [
+                "--transport",
+                "streamable-http",
+                "--http-host",
+                "192.168.1.100",
+                "--http-port",
+                "8080",
+                "--host",
+                "redis.example.com",
+                "--port",
+                "6379",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_server_class.assert_called_once_with(
+            transport="streamable-http", http_host="192.168.1.100", http_port=8080
+        )
+        mock_server.run.assert_called_once()
+
+    @patch("src.main.set_redis_config_from_cli")
+    @patch("src.main.RedisMCPServer")
+    def test_invalid_transport_option(self, mock_server_class, mock_set_config):
+        """Test that invalid transport option is rejected."""
+        mock_server = Mock()
+        mock_server_class.return_value = mock_server
+
+        result = self.runner.invoke(
+            cli,
+            ["--transport", "invalid-transport", "--url", "redis://localhost:6379/0"],
+        )
+
+        assert result.exit_code != 0
+        assert (
+            "Invalid value for '--transport'" in result.output
+            or "Invalid choice" in result.output
+        )
+
+    @patch("src.main.set_redis_config_from_cli")
+    @patch("src.main.RedisMCPServer")
+    def test_stdio_transport_default_behavior(self, mock_server_class, mock_set_config):
+        """Test that stdio is the default transport."""
+        mock_server = Mock()
+        mock_server_class.return_value = mock_server
+
+        result = self.runner.invoke(cli, ["--url", "redis://localhost:6379/0"])
+
+        assert result.exit_code == 0
+        mock_server_class.assert_called_once_with(
+            transport="stdio", http_host="127.0.0.1", http_port=8000
+        )
+        mock_server.run.assert_called_once()
+
+    @patch("src.main.set_redis_config_from_cli")
+    @patch("src.main.RedisMCPServer")
+    def test_http_port_validation(self, mock_server_class, mock_set_config):
+        """Test HTTP port parameter validation."""
+        mock_server = Mock()
+        mock_server_class.return_value = mock_server
+
+        # Test valid port
+        result = self.runner.invoke(
+            cli,
+            [
+                "--transport",
+                "http",
+                "--http-port",
+                "8080",
+                "--url",
+                "redis://localhost:6379/0",
+            ],
+        )
+        assert result.exit_code == 0
+
+        # Test invalid port (should be rejected by Click)
+        result = self.runner.invoke(
+            cli,
+            [
+                "--transport",
+                "http",
+                "--http-port",
+                "invalid",
+                "--url",
+                "redis://localhost:6379/0",
+            ],
+        )
+        assert result.exit_code != 0
+
+    @patch("src.main.set_redis_config_from_cli")
+    @patch("src.main.RedisMCPServer")
+    def test_http_host_validation(self, mock_server_class, mock_set_config):
+        """Test HTTP host parameter with different formats."""
+        mock_server = Mock()
+        mock_server_class.return_value = mock_server
+
+        # Test with IP address
+        result = self.runner.invoke(
+            cli,
+            [
+                "--transport",
+                "sse",
+                "--http-host",
+                "10.0.0.1",
+                "--url",
+                "redis://localhost:6379/0",
+            ],
+        )
+        assert result.exit_code == 0
+
+        # Test with hostname
+        result = self.runner.invoke(
+            cli,
+            [
+                "--transport",
+                "http",
+                "--http-host",
+                "mcp-server.example.com",
+                "--url",
+                "redis://localhost:6379/0",
+            ],
+        )
+        assert result.exit_code == 0
+
+        # Test with localhost
+        result = self.runner.invoke(
+            cli,
+            [
+                "--transport",
+                "streamable-http",
+                "--http-host",
+                "localhost",
+                "--url",
+                "redis://localhost:6379/0",
+            ],
+        )
+        assert result.exit_code == 0


### PR DESCRIPTION
support http ,sse and streamable-http protocol
support Sentinel Connection
Docker container as standalone server 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new runtime modes (HTTP/SSE transports) and Redis topology handling (Sentinel/cluster normalization), which can affect connectivity and deployment behavior across environments.
> 
> **Overview**
> Adds **multi-transport support** to the MCP server (`--transport` with `stdio`/`http`/`sse`/`streamable-http`) including configurable `--http-host`/`--http-port` (also via env), and normalizes `http` to FastMCP’s `streamable-http` at runtime.
> 
> Introduces **Redis topology configuration** (`standalone`/`cluster`/`sentinel`) across env/URI/CLI, including Sentinel master discovery (`sentinel_master_name`, `sentinel_nodes`, optional Sentinel auth) with validation and backward-compatible `--cluster-mode`/`cluster_mode` support.
> 
> Updates Docker packaging to run as a standalone server via `ENTRYPOINT [
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f0af66563ebbd8ea6010c19a619b5a0b0f68ac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->