### PR TITLE
Add stateful Redis pub/sub subscriptions with message polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This MCP Server provides tools to manage the data stored in Redis.
 - `list` tools with common operations to append and pop items. Useful for queues, message brokers, or maintaining a list of most recent actions.
 - `set` tools to add, remove and list set members. Useful for tracking unique values like user IDs or tags, and for performing set operations like intersection.
 - `sorted set` tools to manage data for e.g. leaderboards, priority queues, or time-based analytics with score-based ordering.
-- `pub/sub` functionality to publish messages to channels and subscribe to receive them. Useful for real-time notifications, chat applications, or distributing updates to multiple clients.
+- `pub/sub` functionality to publish messages, create stateful channel or pattern subscriptions, and read queued messages using returned subscription handles. Useful for real-time notifications, chat applications, or distributing updates to multiple clients.
 - `streams` tools to add, read, delete, create and destroy consumer groups, and acknowledge processed entries in data streams. Useful for event sourcing, activity feeds, and worker-based event processing with Redis Streams consumer groups.
 - `JSON` tools to store, retrieve, and manipulate JSON documents in Redis. Useful for complex nested data structures, document databases, or configuration management with path-based access.
 

--- a/src/common/subscription_manager.py
+++ b/src/common/subscription_manager.py
@@ -19,7 +19,10 @@ def _decode_message_value(value: Any) -> Any:
     if isinstance(value, tuple):
         return [_decode_message_value(item) for item in value]
     if isinstance(value, dict):
-        return {key: _decode_message_value(item) for key, item in value.items()}
+        return {
+            _decode_message_value(key): _decode_message_value(item)
+            for key, item in value.items()
+        }
     return value
 
 

--- a/src/common/subscription_manager.py
+++ b/src/common/subscription_manager.py
@@ -1,0 +1,156 @@
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+from redis import Redis
+from redis.client import PubSub
+
+
+def _decode_message_value(value: Any) -> Any:
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return value.hex()
+    if isinstance(value, list):
+        return [_decode_message_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_decode_message_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _decode_message_value(item) for key, item in value.items()}
+    return value
+
+
+@dataclass
+class Subscription:
+    subscription_id: str
+    pubsub: PubSub
+    mode: str
+    targets: List[str]
+    created_at: float = field(default_factory=time.time)
+    lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+
+class SubscriptionManager:
+    _subscriptions: Dict[str, Subscription] = {}
+    _lock = threading.Lock()
+
+    @classmethod
+    def subscribe(cls, redis_client: Redis, channel: str) -> Dict[str, Any]:
+        pubsub = redis_client.pubsub()
+        try:
+            pubsub.subscribe(channel)
+            return cls._store(pubsub, "channel", [channel])
+        except Exception:
+            pubsub.close()
+            raise
+
+    @classmethod
+    def psubscribe(cls, redis_client: Redis, pattern: str) -> Dict[str, Any]:
+        pubsub = redis_client.pubsub()
+        try:
+            pubsub.psubscribe(pattern)
+            return cls._store(pubsub, "pattern", [pattern])
+        except Exception:
+            pubsub.close()
+            raise
+
+    @classmethod
+    def read_messages(
+        cls, subscription_id: str, timeout_ms: int, max_messages: int
+    ) -> Dict[str, Any]:
+        subscription = cls._get(subscription_id)
+        timeout_seconds = timeout_ms / 1000
+        deadline = time.monotonic() + timeout_seconds
+        messages: List[Dict[str, Any]] = []
+
+        with subscription.lock:
+            while len(messages) < max_messages:
+                remaining = max(0.0, deadline - time.monotonic())
+                message = subscription.pubsub.get_message(
+                    ignore_subscribe_messages=True,
+                    timeout=remaining,
+                )
+
+                if message is None:
+                    break
+
+                messages.append(_decode_message_value(message))
+
+        return {
+            "subscription_id": subscription.subscription_id,
+            "message_count": len(messages),
+            "messages": messages,
+        }
+
+    @classmethod
+    def unsubscribe(cls, subscription_id: str) -> Dict[str, Any]:
+        subscription = cls._pop(subscription_id)
+
+        with subscription.lock:
+            try:
+                if subscription.mode == "pattern":
+                    subscription.pubsub.punsubscribe(*subscription.targets)
+                else:
+                    subscription.pubsub.unsubscribe(*subscription.targets)
+            finally:
+                subscription.pubsub.close()
+
+        return {
+            "status": "success",
+            "subscription_id": subscription.subscription_id,
+            "mode": subscription.mode,
+            "targets": subscription.targets,
+        }
+
+    @classmethod
+    def reset(cls) -> None:
+        with cls._lock:
+            subscriptions = list(cls._subscriptions.values())
+            cls._subscriptions = {}
+
+        for subscription in subscriptions:
+            with subscription.lock:
+                subscription.pubsub.close()
+
+    @classmethod
+    def _store(cls, pubsub: PubSub, mode: str, targets: List[str]) -> Dict[str, Any]:
+        subscription_id = uuid.uuid4().hex
+        subscription = Subscription(
+            subscription_id=subscription_id,
+            pubsub=pubsub,
+            mode=mode,
+            targets=targets,
+        )
+
+        with cls._lock:
+            cls._subscriptions[subscription_id] = subscription
+
+        return {
+            "status": "success",
+            "subscription_id": subscription_id,
+            "mode": mode,
+            "targets": targets,
+        }
+
+    @classmethod
+    def _get(cls, subscription_id: str) -> Subscription:
+        with cls._lock:
+            subscription = cls._subscriptions.get(subscription_id)
+
+        if subscription is None:
+            raise KeyError(subscription_id)
+
+        return subscription
+
+    @classmethod
+    def _pop(cls, subscription_id: str) -> Subscription:
+        with cls._lock:
+            subscription = cls._subscriptions.pop(subscription_id, None)
+
+        if subscription is None:
+            raise KeyError(subscription_id)
+
+        return subscription

--- a/src/common/subscription_manager.py
+++ b/src/common/subscription_manager.py
@@ -136,8 +136,12 @@ class SubscriptionManager:
             targets=targets,
         )
 
+        stale_subscriptions = cls._collect_stale_subscriptions()
+        for stale_subscription in stale_subscriptions:
+            with stale_subscription.lock:
+                stale_subscription.pubsub.close()
+
         with cls._lock:
-            cls._cleanup_stale_subscriptions_locked()
             if len(cls._subscriptions) >= cls.MAX_ACTIVE_SUBSCRIPTIONS:
                 raise SubscriptionLimitExceededError(
                     "Too many active subscriptions. Close unused subscriptions and try again."
@@ -162,23 +166,21 @@ class SubscriptionManager:
         return subscription
 
     @classmethod
-    def _cleanup_stale_subscriptions_locked(cls) -> None:
+    def _collect_stale_subscriptions(cls) -> List[Subscription]:
         now = time.time()
-        stale_ids = [
-            subscription_id
-            for subscription_id, subscription in cls._subscriptions.items()
-            if now - subscription.last_accessed_at > cls.STALE_SUBSCRIPTION_TTL_SECONDS
-        ]
+        with cls._lock:
+            stale_ids = [
+                subscription_id
+                for subscription_id, subscription in cls._subscriptions.items()
+                if now - subscription.last_accessed_at
+                > cls.STALE_SUBSCRIPTION_TTL_SECONDS
+            ]
 
-        stale_subscriptions = [
-            cls._subscriptions.pop(subscription_id)
-            for subscription_id in stale_ids
-            if subscription_id in cls._subscriptions
-        ]
-
-        for subscription in stale_subscriptions:
-            with subscription.lock:
-                subscription.pubsub.close()
+            return [
+                cls._subscriptions.pop(subscription_id)
+                for subscription_id in stale_ids
+                if subscription_id in cls._subscriptions
+            ]
 
     @classmethod
     def _pop(cls, subscription_id: str) -> Subscription:

--- a/src/common/subscription_manager.py
+++ b/src/common/subscription_manager.py
@@ -47,7 +47,7 @@ class SubscriptionManager:
     _subscriptions: Dict[str, Subscription] = {}
     _lock = threading.Lock()
     _stale_slots_reserved = 0
-    MAX_ACTIVE_SUBSCRIPTIONS = 1000
+    MAX_ACTIVE_SUBSCRIPTIONS = 50
     STALE_SUBSCRIPTION_TTL_SECONDS = 300
 
     @classmethod

--- a/src/common/subscription_manager.py
+++ b/src/common/subscription_manager.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 import time
 import uuid
@@ -6,6 +7,8 @@ from typing import Any, Dict, List
 
 from redis import Redis
 from redis.client import PubSub
+
+logger = logging.getLogger(__name__)
 
 
 class SubscriptionLimitExceededError(Exception):
@@ -126,8 +129,12 @@ class SubscriptionManager:
             try:
                 with subscription.lock:
                     subscription.pubsub.close()
-            except Exception:
-                continue
+            except Exception as exc:
+                logger.warning(
+                    "Failed to close pubsub during reset for subscription %s: %s",
+                    subscription.subscription_id,
+                    exc,
+                )
 
     @classmethod
     def _store(cls, pubsub: PubSub, mode: str, targets: List[str]) -> Dict[str, Any]:

--- a/src/common/subscription_manager.py
+++ b/src/common/subscription_manager.py
@@ -39,7 +39,6 @@ class Subscription:
     pubsub: PubSub
     mode: str
     targets: List[str]
-    created_at: float = field(default_factory=time.time)
     last_accessed_at: float = field(default_factory=time.time)
     lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 

--- a/src/common/subscription_manager.py
+++ b/src/common/subscription_manager.py
@@ -47,6 +47,7 @@ class Subscription:
 class SubscriptionManager:
     _subscriptions: Dict[str, Subscription] = {}
     _lock = threading.Lock()
+    _stale_slots_reserved = 0
     MAX_ACTIVE_SUBSCRIPTIONS = 1000
     STALE_SUBSCRIPTION_TTL_SECONDS = 300
 
@@ -124,6 +125,7 @@ class SubscriptionManager:
         with cls._lock:
             subscriptions = list(cls._subscriptions.values())
             cls._subscriptions = {}
+            cls._stale_slots_reserved = 0
 
         for subscription in subscriptions:
             try:
@@ -150,7 +152,8 @@ class SubscriptionManager:
         cls._close_stale_subscriptions(stale_subscriptions)
 
         with cls._lock:
-            if len(cls._subscriptions) >= cls.MAX_ACTIVE_SUBSCRIPTIONS:
+            total_active = len(cls._subscriptions) + cls._stale_slots_reserved
+            if total_active >= cls.MAX_ACTIVE_SUBSCRIPTIONS:
                 raise SubscriptionLimitExceededError(
                     "Too many active subscriptions. Close unused subscriptions and try again."
                 )
@@ -184,11 +187,13 @@ class SubscriptionManager:
                 > cls.STALE_SUBSCRIPTION_TTL_SECONDS
             ]
 
-            return [
+            stale_subscriptions = [
                 cls._subscriptions.pop(subscription_id)
                 for subscription_id in stale_ids
                 if subscription_id in cls._subscriptions
             ]
+            cls._stale_slots_reserved += len(stale_subscriptions)
+            return stale_subscriptions
 
     @classmethod
     def _close_stale_subscriptions(
@@ -206,6 +211,11 @@ class SubscriptionManager:
             with cls._lock:
                 for subscription in failed_to_close:
                     cls._subscriptions[subscription.subscription_id] = subscription
+
+        with cls._lock:
+            cls._stale_slots_reserved = max(
+                0, cls._stale_slots_reserved - len(stale_subscriptions)
+            )
 
     @classmethod
     def _pop(cls, subscription_id: str) -> Subscription:

--- a/src/common/subscription_manager.py
+++ b/src/common/subscription_manager.py
@@ -123,8 +123,11 @@ class SubscriptionManager:
             cls._subscriptions = {}
 
         for subscription in subscriptions:
-            with subscription.lock:
-                subscription.pubsub.close()
+            try:
+                with subscription.lock:
+                    subscription.pubsub.close()
+            except Exception:
+                continue
 
     @classmethod
     def _store(cls, pubsub: PubSub, mode: str, targets: List[str]) -> Dict[str, Any]:

--- a/src/common/subscription_manager.py
+++ b/src/common/subscription_manager.py
@@ -8,6 +8,10 @@ from redis import Redis
 from redis.client import PubSub
 
 
+class SubscriptionLimitExceededError(Exception):
+    """Raised when a new subscription cannot be created due to capacity limits."""
+
+
 def _decode_message_value(value: Any) -> Any:
     if isinstance(value, bytes):
         try:
@@ -33,12 +37,15 @@ class Subscription:
     mode: str
     targets: List[str]
     created_at: float = field(default_factory=time.time)
+    last_accessed_at: float = field(default_factory=time.time)
     lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 
 
 class SubscriptionManager:
     _subscriptions: Dict[str, Subscription] = {}
     _lock = threading.Lock()
+    MAX_ACTIVE_SUBSCRIPTIONS = 1000
+    STALE_SUBSCRIPTION_TTL_SECONDS = 300
 
     @classmethod
     def subscribe(cls, redis_client: Redis, channel: str) -> Dict[str, Any]:
@@ -70,6 +77,7 @@ class SubscriptionManager:
         messages: List[Dict[str, Any]] = []
 
         with subscription.lock:
+            subscription.last_accessed_at = time.time()
             while len(messages) < max_messages:
                 remaining = max(0.0, deadline - time.monotonic())
                 message = subscription.pubsub.get_message(
@@ -129,6 +137,11 @@ class SubscriptionManager:
         )
 
         with cls._lock:
+            cls._cleanup_stale_subscriptions_locked()
+            if len(cls._subscriptions) >= cls.MAX_ACTIVE_SUBSCRIPTIONS:
+                raise SubscriptionLimitExceededError(
+                    "Too many active subscriptions. Close unused subscriptions and try again."
+                )
             cls._subscriptions[subscription_id] = subscription
 
         return {
@@ -147,6 +160,25 @@ class SubscriptionManager:
             raise KeyError(subscription_id)
 
         return subscription
+
+    @classmethod
+    def _cleanup_stale_subscriptions_locked(cls) -> None:
+        now = time.time()
+        stale_ids = [
+            subscription_id
+            for subscription_id, subscription in cls._subscriptions.items()
+            if now - subscription.last_accessed_at > cls.STALE_SUBSCRIPTION_TTL_SECONDS
+        ]
+
+        stale_subscriptions = [
+            cls._subscriptions.pop(subscription_id)
+            for subscription_id in stale_ids
+            if subscription_id in cls._subscriptions
+        ]
+
+        for subscription in stale_subscriptions:
+            with subscription.lock:
+                subscription.pubsub.close()
 
     @classmethod
     def _pop(cls, subscription_id: str) -> Subscription:

--- a/src/common/subscription_manager.py
+++ b/src/common/subscription_manager.py
@@ -73,10 +73,10 @@ class SubscriptionManager:
     ) -> Dict[str, Any]:
         subscription = cls._get(subscription_id)
         timeout_seconds = timeout_ms / 1000
-        deadline = time.monotonic() + timeout_seconds
         messages: List[Dict[str, Any]] = []
 
         with subscription.lock:
+            deadline = time.monotonic() + timeout_seconds
             subscription.last_accessed_at = time.time()
             while len(messages) < max_messages:
                 remaining = max(0.0, deadline - time.monotonic())

--- a/src/common/subscription_manager.py
+++ b/src/common/subscription_manager.py
@@ -137,9 +137,7 @@ class SubscriptionManager:
         )
 
         stale_subscriptions = cls._collect_stale_subscriptions()
-        for stale_subscription in stale_subscriptions:
-            with stale_subscription.lock:
-                stale_subscription.pubsub.close()
+        cls._close_stale_subscriptions(stale_subscriptions)
 
         with cls._lock:
             if len(cls._subscriptions) >= cls.MAX_ACTIVE_SUBSCRIPTIONS:
@@ -181,6 +179,23 @@ class SubscriptionManager:
                 for subscription_id in stale_ids
                 if subscription_id in cls._subscriptions
             ]
+
+    @classmethod
+    def _close_stale_subscriptions(
+        cls, stale_subscriptions: List[Subscription]
+    ) -> None:
+        failed_to_close: List[Subscription] = []
+        for stale_subscription in stale_subscriptions:
+            try:
+                with stale_subscription.lock:
+                    stale_subscription.pubsub.close()
+            except Exception:
+                failed_to_close.append(stale_subscription)
+
+        if failed_to_close:
+            with cls._lock:
+                for subscription in failed_to_close:
+                    cls._subscriptions[subscription.subscription_id] = subscription
 
     @classmethod
     def _pop(cls, subscription_id: str) -> Subscription:

--- a/src/tools/pub_sub.py
+++ b/src/tools/pub_sub.py
@@ -116,8 +116,10 @@ async def unsubscribe(subscription_id: str) -> Dict[str, Any]:
         A dictionary describing the closed subscription or an error message.
     """
     try:
-        result = SubscriptionManager.unsubscribe(subscription_id)
-        return result
+        return await asyncio.to_thread(
+            SubscriptionManager.unsubscribe,
+            subscription_id,
+        )
     except KeyError:
         return {"error": f"Subscription '{subscription_id}' was not found"}
     except RedisError as e:

--- a/src/tools/pub_sub.py
+++ b/src/tools/pub_sub.py
@@ -1,7 +1,10 @@
+from typing import Any, Dict
+
 from redis.exceptions import RedisError
 
 from src.common.connection import RedisConnectionManager
 from src.common.server import mcp
+from src.common.subscription_manager import SubscriptionManager
 
 
 @mcp.tool()
@@ -24,38 +27,98 @@ async def publish(channel: str, message: str) -> str:
 
 
 @mcp.tool()
-async def subscribe(channel: str) -> str:
-    """Subscribe to a Redis channel.
+async def subscribe(channel: str) -> Dict[str, Any]:
+    """Subscribe to a Redis channel and return a reusable subscription handle.
 
     Args:
         channel: The Redis channel to subscribe to.
 
     Returns:
-        A success message or an error message.
+        A dictionary containing the subscription ID or an error message.
     """
     try:
         r = RedisConnectionManager.get_connection()
-        pubsub = r.pubsub()
-        pubsub.subscribe(channel)
-        return f"Subscribed to channel '{channel}'."
+        subscription = SubscriptionManager.subscribe(r, channel)
+        return subscription
     except RedisError as e:
-        return f"Error subscribing to channel '{channel}': {str(e)}"
+        return {"error": f"Error subscribing to channel '{channel}': {str(e)}"}
 
 
 @mcp.tool()
-async def unsubscribe(channel: str) -> str:
-    """Unsubscribe from a Redis channel.
+async def psubscribe(pattern: str) -> Dict[str, Any]:
+    """Subscribe to Redis channels using a pattern.
 
     Args:
-        channel: The Redis channel to unsubscribe from.
+        pattern: The Redis channel pattern to subscribe to.
 
     Returns:
-        A success message or an error message.
+        A dictionary containing the subscription ID or an error message.
     """
     try:
         r = RedisConnectionManager.get_connection()
-        pubsub = r.pubsub()
-        pubsub.unsubscribe(channel)
-        return f"Unsubscribed from channel '{channel}'."
+        subscription = SubscriptionManager.psubscribe(r, pattern)
+        return subscription
     except RedisError as e:
-        return f"Error unsubscribing from channel '{channel}': {str(e)}"
+        return {
+            "error": f"Error subscribing to pattern '{pattern}': {str(e)}",
+        }
+
+
+@mcp.tool()
+async def read_messages(
+    subscription_id: str, timeout_ms: int = 1000, max_messages: int = 10
+) -> Dict[str, Any]:
+    """Read pending pub/sub messages for an existing subscription.
+
+    Args:
+        subscription_id: The ID returned by subscribe() or psubscribe().
+        timeout_ms: Time to wait for messages in milliseconds. Use 0 for non-blocking.
+        max_messages: Maximum number of messages to return in one call.
+
+    Returns:
+        A dictionary containing the collected messages or an error message.
+    """
+    if timeout_ms < 0:
+        return {"error": "timeout_ms must be greater than or equal to 0"}
+    if timeout_ms > 5000:
+        return {"error": "timeout_ms must be less than or equal to 5000"}
+    if max_messages < 1:
+        return {"error": "max_messages must be greater than 0"}
+    if max_messages > 100:
+        return {"error": "max_messages must be less than or equal to 100"}
+
+    try:
+        return SubscriptionManager.read_messages(
+            subscription_id, timeout_ms=timeout_ms, max_messages=max_messages
+        )
+    except KeyError:
+        return {"error": f"Subscription '{subscription_id}' was not found"}
+    except RedisError as e:
+        return {
+            "error": (
+                f"Error reading messages for subscription '{subscription_id}': {str(e)}"
+            )
+        }
+
+
+@mcp.tool()
+async def unsubscribe(subscription_id: str) -> Dict[str, Any]:
+    """Unsubscribe and close an existing pub/sub subscription.
+
+    Args:
+        subscription_id: The ID returned by subscribe() or psubscribe().
+
+    Returns:
+        A dictionary describing the closed subscription or an error message.
+    """
+    try:
+        result = SubscriptionManager.unsubscribe(subscription_id)
+        return result
+    except KeyError:
+        return {"error": f"Subscription '{subscription_id}' was not found"}
+    except RedisError as e:
+        return {
+            "error": (
+                f"Error unsubscribing from subscription '{subscription_id}': {str(e)}"
+            )
+        }

--- a/src/tools/pub_sub.py
+++ b/src/tools/pub_sub.py
@@ -39,7 +39,11 @@ async def subscribe(channel: str) -> Dict[str, Any]:
     """
     try:
         r = RedisConnectionManager.get_connection()
-        subscription = SubscriptionManager.subscribe(r, channel)
+        subscription = await asyncio.to_thread(
+            SubscriptionManager.subscribe,
+            r,
+            channel,
+        )
         return subscription
     except RedisError as e:
         return {"error": f"Error subscribing to channel '{channel}': {str(e)}"}
@@ -57,7 +61,11 @@ async def psubscribe(pattern: str) -> Dict[str, Any]:
     """
     try:
         r = RedisConnectionManager.get_connection()
-        subscription = SubscriptionManager.psubscribe(r, pattern)
+        subscription = await asyncio.to_thread(
+            SubscriptionManager.psubscribe,
+            r,
+            pattern,
+        )
         return subscription
     except RedisError as e:
         return {

--- a/src/tools/pub_sub.py
+++ b/src/tools/pub_sub.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Dict
 
 from redis.exceptions import RedisError
@@ -88,8 +89,11 @@ async def read_messages(
         return {"error": "max_messages must be less than or equal to 100"}
 
     try:
-        return SubscriptionManager.read_messages(
-            subscription_id, timeout_ms=timeout_ms, max_messages=max_messages
+        return await asyncio.to_thread(
+            SubscriptionManager.read_messages,
+            subscription_id,
+            timeout_ms,
+            max_messages,
         )
     except KeyError:
         return {"error": f"Subscription '{subscription_id}' was not found"}

--- a/src/tools/pub_sub.py
+++ b/src/tools/pub_sub.py
@@ -5,7 +5,10 @@ from redis.exceptions import RedisError
 
 from src.common.connection import RedisConnectionManager
 from src.common.server import mcp
-from src.common.subscription_manager import SubscriptionManager
+from src.common.subscription_manager import (
+    SubscriptionLimitExceededError,
+    SubscriptionManager,
+)
 
 
 @mcp.tool()
@@ -47,6 +50,8 @@ async def subscribe(channel: str) -> Dict[str, Any]:
         return subscription
     except RedisError as e:
         return {"error": f"Error subscribing to channel '{channel}': {str(e)}"}
+    except SubscriptionLimitExceededError as e:
+        return {"error": str(e)}
 
 
 @mcp.tool()
@@ -71,6 +76,8 @@ async def psubscribe(pattern: str) -> Dict[str, Any]:
         return {
             "error": f"Error subscribing to pattern '{pattern}': {str(e)}",
         }
+    except SubscriptionLimitExceededError as e:
+        return {"error": str(e)}
 
 
 @mcp.tool()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,16 @@ def reset_connection_manager():
     RedisConnectionManager._instance = None
 
 
+@pytest.fixture(autouse=True)
+def reset_subscription_manager():
+    """Reset the pub/sub subscription registry before each test."""
+    from src.common.subscription_manager import SubscriptionManager
+
+    SubscriptionManager.reset()
+    yield
+    SubscriptionManager.reset()
+
+
 @pytest.fixture
 def mock_numpy_array():
     """Mock numpy array for vector testing."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -219,6 +219,8 @@ class TestMCPServerIntegration:
             "scan_all_keys",
             "search_redis_documents",
             "publish",
+            "psubscribe",
+            "read_messages",
             "subscribe",
             "unsubscribe",
             "get_indexes",
@@ -247,9 +249,9 @@ class TestMCPServerIntegration:
             "lrem",
         ]
         for tool in tool_names:
-            assert tool in expected_tools, (
-                f"Expected tool '{tool}' not found in {tool_names}"
-            )
+            assert (
+                tool in expected_tools
+            ), f"Expected tool '{tool}' not found in {tool_names}"
 
     def test_server_tool_count_and_names(self, server_process):
         """Test that the server registers the correct number of tools with expected names."""
@@ -275,10 +277,10 @@ class TestMCPServerIntegration:
         tool_names = [tool["name"] for tool in tools]
 
         # Expected tool count (based on @mcp.tool() decorators in codebase)
-        expected_tool_count = 51
-        assert len(tools) == expected_tool_count, (
-            f"Expected {expected_tool_count} tools, but got {len(tools)}"
-        )
+        expected_tool_count = 53
+        assert (
+            len(tools) == expected_tool_count
+        ), f"Expected {expected_tool_count} tools, but got {len(tools)}"
 
         # Expected tool names (alphabetically sorted for easier verification)
         expected_tools = [
@@ -308,6 +310,8 @@ class TestMCPServerIntegration:
             "lpush",
             "lrange",
             "publish",
+            "psubscribe",
+            "read_messages",
             "rename",
             "rpop",
             "rpush",
@@ -359,7 +363,13 @@ class TestMCPServerIntegration:
                 "xack",
             ],
             "json": ["json_get", "json_set", "json_del"],
-            "pub_sub": ["publish", "subscribe", "unsubscribe"],
+            "pub_sub": [
+                "publish",
+                "psubscribe",
+                "read_messages",
+                "subscribe",
+                "unsubscribe",
+            ],
             "server_mgmt": ["dbsize", "info", "client_list"],
             "misc": [
                 "delete",
@@ -383,9 +393,9 @@ class TestMCPServerIntegration:
 
         for category, category_tools in tool_categories.items():
             for tool in category_tools:
-                assert tool in tool_names, (
-                    f"Tool '{tool}' from category '{category}' not found in registered tools"
-                )
+                assert (
+                    tool in tool_names
+                ), f"Tool '{tool}' from category '{category}' not found in registered tools"
 
     def _initialize_server(self, server_process):
         """Helper to initialize the MCP server."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -249,9 +249,9 @@ class TestMCPServerIntegration:
             "lrem",
         ]
         for tool in tool_names:
-            assert (
-                tool in expected_tools
-            ), f"Expected tool '{tool}' not found in {tool_names}"
+            assert tool in expected_tools, (
+                f"Expected tool '{tool}' not found in {tool_names}"
+            )
 
     def test_server_tool_count_and_names(self, server_process):
         """Test that the server registers the correct number of tools with expected names."""
@@ -278,9 +278,9 @@ class TestMCPServerIntegration:
 
         # Expected tool count (based on @mcp.tool() decorators in codebase)
         expected_tool_count = 53
-        assert (
-            len(tools) == expected_tool_count
-        ), f"Expected {expected_tool_count} tools, but got {len(tools)}"
+        assert len(tools) == expected_tool_count, (
+            f"Expected {expected_tool_count} tools, but got {len(tools)}"
+        )
 
         # Expected tool names (alphabetically sorted for easier verification)
         expected_tools = [
@@ -393,9 +393,9 @@ class TestMCPServerIntegration:
 
         for category, category_tools in tool_categories.items():
             for tool in category_tools:
-                assert (
-                    tool in tool_names
-                ), f"Tool '{tool}' from category '{category}' not found in registered tools"
+                assert tool in tool_names, (
+                    f"Tool '{tool}' from category '{category}' not found in registered tools"
+                )
 
     def _initialize_server(self, server_process):
         """Helper to initialize the MCP server."""

--- a/tests/tools/test_pub_sub.py
+++ b/tests/tools/test_pub_sub.py
@@ -207,6 +207,62 @@ class TestPubSubOperations:
         }
 
     @pytest.mark.asyncio
+    async def test_subscribe_uses_asyncio_to_thread(
+        self, mock_redis_connection_manager
+    ):
+        """Test subscribe offloads blocking connection setup to a worker thread."""
+        mock_redis = mock_redis_connection_manager
+        expected = {
+            "status": "success",
+            "subscription_id": "sub-123",
+            "mode": "channel",
+            "targets": ["orders"],
+        }
+
+        with (
+            patch("src.tools.pub_sub.asyncio.to_thread") as mock_to_thread,
+            patch("src.tools.pub_sub.SubscriptionManager.subscribe") as mock_subscribe,
+        ):
+            mock_to_thread.return_value = expected
+
+            result = await subscribe("orders")
+
+            mock_to_thread.assert_awaited_once_with(
+                mock_subscribe,
+                mock_redis,
+                "orders",
+            )
+            assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_psubscribe_uses_asyncio_to_thread(
+        self, mock_redis_connection_manager
+    ):
+        """Test psubscribe offloads blocking connection setup to a worker thread."""
+        mock_redis = mock_redis_connection_manager
+        expected = {
+            "status": "success",
+            "subscription_id": "sub-456",
+            "mode": "pattern",
+            "targets": ["orders:*"],
+        }
+
+        with (
+            patch("src.tools.pub_sub.asyncio.to_thread") as mock_to_thread,
+            patch("src.tools.pub_sub.SubscriptionManager.psubscribe") as mock_psub,
+        ):
+            mock_to_thread.return_value = expected
+
+            result = await psubscribe("orders:*")
+
+            mock_to_thread.assert_awaited_once_with(
+                mock_psub,
+                mock_redis,
+                "orders:*",
+            )
+            assert result == expected
+
+    @pytest.mark.asyncio
     async def test_read_messages_success(self, mock_redis_connection_manager):
         """Test reading messages from an active subscription."""
         mock_redis = mock_redis_connection_manager

--- a/tests/tools/test_pub_sub.py
+++ b/tests/tools/test_pub_sub.py
@@ -335,6 +335,26 @@ class TestPubSubOperations:
         }
 
     @pytest.mark.asyncio
+    async def test_read_messages_uses_asyncio_to_thread(self):
+        """Test read_messages offloads blocking polling to a worker thread."""
+        expected = {
+            "subscription_id": "sub-123",
+            "message_count": 0,
+            "messages": [],
+        }
+
+        with (
+            patch("src.tools.pub_sub.asyncio.to_thread") as mock_to_thread,
+            patch("src.tools.pub_sub.SubscriptionManager.read_messages") as mock_read,
+        ):
+            mock_to_thread.return_value = expected
+
+            result = await read_messages("sub-123", timeout_ms=250, max_messages=3)
+
+            mock_to_thread.assert_awaited_once_with(mock_read, "sub-123", 250, 3)
+            assert result == expected
+
+    @pytest.mark.asyncio
     async def test_unsubscribe_success(self, mock_redis_connection_manager):
         """Test successful channel unsubscribe operation."""
         mock_redis = mock_redis_connection_manager

--- a/tests/tools/test_pub_sub.py
+++ b/tests/tools/test_pub_sub.py
@@ -7,7 +7,8 @@ from unittest.mock import Mock, patch
 import pytest
 from redis.exceptions import ConnectionError, RedisError
 
-from src.tools.pub_sub import publish, subscribe, unsubscribe
+from src.common.subscription_manager import SubscriptionManager
+from src.tools.pub_sub import psubscribe, publish, read_messages, subscribe, unsubscribe
 
 
 class TestPubSubOperations:
@@ -17,9 +18,7 @@ class TestPubSubOperations:
     async def test_publish_success(self, mock_redis_connection_manager):
         """Test successful publish operation."""
         mock_redis = mock_redis_connection_manager
-        mock_redis.publish.return_value = (
-            2  # Number of subscribers that received the message
-        )
+        mock_redis.publish.return_value = 2
 
         result = await publish("test_channel", "Hello World")
 
@@ -30,7 +29,7 @@ class TestPubSubOperations:
     async def test_publish_no_subscribers(self, mock_redis_connection_manager):
         """Test publish operation with no subscribers."""
         mock_redis = mock_redis_connection_manager
-        mock_redis.publish.return_value = 0  # No subscribers
+        mock_redis.publish.return_value = 0
 
         result = await publish("empty_channel", "Hello World")
 
@@ -112,114 +111,16 @@ class TestPubSubOperations:
         assert "Message published to channel 'test_channel'" in result
 
     @pytest.mark.asyncio
-    async def test_subscribe_success(self, mock_redis_connection_manager):
-        """Test successful subscribe operation."""
+    async def test_publish_large_message(self, mock_redis_connection_manager):
+        """Test publish operation with large message."""
         mock_redis = mock_redis_connection_manager
-        mock_pubsub = Mock()
-        mock_redis.pubsub.return_value = mock_pubsub
-        mock_pubsub.subscribe.return_value = None
+        mock_redis.publish.return_value = 1
 
-        result = await subscribe("test_channel")
+        large_message = "x" * 10000
+        result = await publish("test_channel", large_message)
 
-        mock_redis.pubsub.assert_called_once()
-        mock_pubsub.subscribe.assert_called_once_with("test_channel")
-        assert "Subscribed to channel 'test_channel'" in result
-
-    @pytest.mark.asyncio
-    async def test_subscribe_redis_error(self, mock_redis_connection_manager):
-        """Test subscribe operation with Redis error."""
-        mock_redis = mock_redis_connection_manager
-        mock_redis.pubsub.side_effect = RedisError("Connection failed")
-
-        result = await subscribe("test_channel")
-
-        assert (
-            "Error subscribing to channel 'test_channel': Connection failed" in result
-        )
-
-    @pytest.mark.asyncio
-    async def test_subscribe_pubsub_error(self, mock_redis_connection_manager):
-        """Test subscribe operation with pubsub creation error."""
-        mock_redis = mock_redis_connection_manager
-        mock_pubsub = Mock()
-        mock_redis.pubsub.return_value = mock_pubsub
-        mock_pubsub.subscribe.side_effect = RedisError("Subscribe failed")
-
-        result = await subscribe("test_channel")
-
-        assert "Error subscribing to channel 'test_channel': Subscribe failed" in result
-
-    @pytest.mark.asyncio
-    async def test_subscribe_multiple_channels_pattern(
-        self, mock_redis_connection_manager
-    ):
-        """Test subscribe operation with pattern-like channel name."""
-        mock_redis = mock_redis_connection_manager
-        mock_pubsub = Mock()
-        mock_redis.pubsub.return_value = mock_pubsub
-        mock_pubsub.subscribe.return_value = None
-
-        pattern_channel = "notifications:*"
-        result = await subscribe(pattern_channel)
-
-        mock_pubsub.subscribe.assert_called_once_with(pattern_channel)
-        assert f"Subscribed to channel '{pattern_channel}'" in result
-
-    @pytest.mark.asyncio
-    async def test_unsubscribe_success(self, mock_redis_connection_manager):
-        """Test successful unsubscribe operation."""
-        mock_redis = mock_redis_connection_manager
-        mock_pubsub = Mock()
-        mock_redis.pubsub.return_value = mock_pubsub
-        mock_pubsub.unsubscribe.return_value = None
-
-        result = await unsubscribe("test_channel")
-
-        mock_redis.pubsub.assert_called_once()
-        mock_pubsub.unsubscribe.assert_called_once_with("test_channel")
-        assert "Unsubscribed from channel 'test_channel'" in result
-
-    @pytest.mark.asyncio
-    async def test_unsubscribe_redis_error(self, mock_redis_connection_manager):
-        """Test unsubscribe operation with Redis error."""
-        mock_redis = mock_redis_connection_manager
-        mock_redis.pubsub.side_effect = RedisError("Connection failed")
-
-        result = await unsubscribe("test_channel")
-
-        assert (
-            "Error unsubscribing from channel 'test_channel': Connection failed"
-            in result
-        )
-
-    @pytest.mark.asyncio
-    async def test_unsubscribe_pubsub_error(self, mock_redis_connection_manager):
-        """Test unsubscribe operation with pubsub error."""
-        mock_redis = mock_redis_connection_manager
-        mock_pubsub = Mock()
-        mock_redis.pubsub.return_value = mock_pubsub
-        mock_pubsub.unsubscribe.side_effect = RedisError("Unsubscribe failed")
-
-        result = await unsubscribe("test_channel")
-
-        assert (
-            "Error unsubscribing from channel 'test_channel': Unsubscribe failed"
-            in result
-        )
-
-    @pytest.mark.asyncio
-    async def test_unsubscribe_from_all_channels(self, mock_redis_connection_manager):
-        """Test unsubscribe operation without specifying channel (unsubscribe from all)."""
-        mock_redis = mock_redis_connection_manager
-        mock_pubsub = Mock()
-        mock_redis.pubsub.return_value = mock_pubsub
-        mock_pubsub.unsubscribe.return_value = None
-
-        # Test unsubscribing from specific channel
-        result = await unsubscribe("specific_channel")
-
-        mock_pubsub.unsubscribe.assert_called_once_with("specific_channel")
-        assert "Unsubscribed from channel 'specific_channel'" in result
+        mock_redis.publish.assert_called_once_with("test_channel", large_message)
+        assert "Message published to channel 'test_channel'" in result
 
     @pytest.mark.asyncio
     async def test_publish_to_pattern_channel(self, mock_redis_connection_manager):
@@ -234,6 +135,269 @@ class TestPubSubOperations:
         assert f"Message published to channel '{pattern_channel}'" in result
 
     @pytest.mark.asyncio
+    async def test_subscribe_success(self, mock_redis_connection_manager):
+        """Test successful channel subscribe operation."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        result = await subscribe("test_channel")
+
+        subscription_id = result["subscription_id"]
+        mock_redis.pubsub.assert_called_once()
+        mock_pubsub.subscribe.assert_called_once_with("test_channel")
+        assert result["status"] == "success"
+        assert result["mode"] == "channel"
+        assert result["targets"] == ["test_channel"]
+        assert subscription_id in SubscriptionManager._subscriptions
+
+    @pytest.mark.asyncio
+    async def test_subscribe_redis_error(self, mock_redis_connection_manager):
+        """Test subscribe operation with Redis error."""
+        mock_redis = mock_redis_connection_manager
+        mock_redis.pubsub.side_effect = RedisError("Connection failed")
+
+        result = await subscribe("test_channel")
+
+        assert result == {
+            "error": "Error subscribing to channel 'test_channel': Connection failed"
+        }
+
+    @pytest.mark.asyncio
+    async def test_subscribe_pubsub_error(self, mock_redis_connection_manager):
+        """Test subscribe operation when the subscribe call fails."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_redis.pubsub.return_value = mock_pubsub
+        mock_pubsub.subscribe.side_effect = RedisError("Subscribe failed")
+
+        result = await subscribe("test_channel")
+
+        mock_pubsub.close.assert_called_once()
+        assert result == {
+            "error": "Error subscribing to channel 'test_channel': Subscribe failed"
+        }
+
+    @pytest.mark.asyncio
+    async def test_psubscribe_success(self, mock_redis_connection_manager):
+        """Test successful pattern subscribe operation."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        result = await psubscribe("notifications:*")
+
+        subscription_id = result["subscription_id"]
+        mock_pubsub.psubscribe.assert_called_once_with("notifications:*")
+        assert result["status"] == "success"
+        assert result["mode"] == "pattern"
+        assert result["targets"] == ["notifications:*"]
+        assert subscription_id in SubscriptionManager._subscriptions
+
+    @pytest.mark.asyncio
+    async def test_psubscribe_redis_error(self, mock_redis_connection_manager):
+        """Test pattern subscribe operation with Redis error."""
+        mock_redis = mock_redis_connection_manager
+        mock_redis.pubsub.side_effect = RedisError("Connection failed")
+
+        result = await psubscribe("notifications:*")
+
+        assert result == {
+            "error": "Error subscribing to pattern 'notifications:*': Connection failed"
+        }
+
+    @pytest.mark.asyncio
+    async def test_read_messages_success(self, mock_redis_connection_manager):
+        """Test reading messages from an active subscription."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_pubsub.get_message.side_effect = [
+            {
+                "type": "message",
+                "channel": b"test_channel",
+                "pattern": None,
+                "data": b"Hello World",
+            },
+            None,
+        ]
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        subscription = await subscribe("test_channel")
+        result = await read_messages(subscription["subscription_id"], max_messages=5)
+
+        assert result == {
+            "subscription_id": subscription["subscription_id"],
+            "message_count": 1,
+            "messages": [
+                {
+                    "type": "message",
+                    "channel": "test_channel",
+                    "pattern": None,
+                    "data": "Hello World",
+                }
+            ],
+        }
+        assert mock_pubsub.get_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_read_messages_multiple_without_blocking(
+        self, mock_redis_connection_manager
+    ):
+        """Test non-blocking reads consume multiple queued messages."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_pubsub.get_message.side_effect = [
+            {
+                "type": "message",
+                "channel": b"test_channel",
+                "pattern": None,
+                "data": b"first",
+            },
+            {
+                "type": "message",
+                "channel": b"test_channel",
+                "pattern": None,
+                "data": b"second",
+            },
+            None,
+        ]
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        subscription = await subscribe("test_channel")
+        result = await read_messages(
+            subscription["subscription_id"], timeout_ms=0, max_messages=10
+        )
+
+        assert result["message_count"] == 2
+        assert [message["data"] for message in result["messages"]] == [
+            "first",
+            "second",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_read_messages_returns_empty_list_when_no_messages(
+        self, mock_redis_connection_manager
+    ):
+        """Test reading when no messages are currently available."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_pubsub.get_message.return_value = None
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        subscription = await subscribe("test_channel")
+        result = await read_messages(subscription["subscription_id"])
+
+        assert result == {
+            "subscription_id": subscription["subscription_id"],
+            "message_count": 0,
+            "messages": [],
+        }
+
+    @pytest.mark.asyncio
+    async def test_read_messages_unknown_subscription(self):
+        """Test reading with an unknown subscription ID."""
+        result = await read_messages("missing-subscription")
+
+        assert result == {"error": "Subscription 'missing-subscription' was not found"}
+
+    @pytest.mark.asyncio
+    async def test_read_messages_validation(self):
+        """Test read_messages input validation."""
+        assert await read_messages("sub-1", timeout_ms=-1) == {
+            "error": "timeout_ms must be greater than or equal to 0"
+        }
+        assert await read_messages("sub-1", timeout_ms=6000) == {
+            "error": "timeout_ms must be less than or equal to 5000"
+        }
+        assert await read_messages("sub-1", max_messages=0) == {
+            "error": "max_messages must be greater than 0"
+        }
+        assert await read_messages("sub-1", max_messages=101) == {
+            "error": "max_messages must be less than or equal to 100"
+        }
+
+    @pytest.mark.asyncio
+    async def test_read_messages_redis_error(self, mock_redis_connection_manager):
+        """Test read_messages when Redis returns an error."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_pubsub.get_message.side_effect = RedisError("Read failed")
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        subscription = await subscribe("test_channel")
+        result = await read_messages(subscription["subscription_id"])
+
+        assert result == {
+            "error": (
+                f"Error reading messages for subscription "
+                f"'{subscription['subscription_id']}': Read failed"
+            )
+        }
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_success(self, mock_redis_connection_manager):
+        """Test successful channel unsubscribe operation."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        subscription = await subscribe("test_channel")
+        result = await unsubscribe(subscription["subscription_id"])
+
+        mock_pubsub.unsubscribe.assert_called_once_with("test_channel")
+        mock_pubsub.close.assert_called_once()
+        assert result == {
+            "status": "success",
+            "subscription_id": subscription["subscription_id"],
+            "mode": "channel",
+            "targets": ["test_channel"],
+        }
+        assert subscription["subscription_id"] not in SubscriptionManager._subscriptions
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_pattern_subscription(
+        self, mock_redis_connection_manager
+    ):
+        """Test successful pattern unsubscribe operation."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        subscription = await psubscribe("events:*")
+        result = await unsubscribe(subscription["subscription_id"])
+
+        mock_pubsub.punsubscribe.assert_called_once_with("events:*")
+        mock_pubsub.close.assert_called_once()
+        assert result["mode"] == "pattern"
+        assert result["targets"] == ["events:*"]
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_unknown_subscription(self):
+        """Test unsubscribe with an unknown subscription ID."""
+        result = await unsubscribe("missing-subscription")
+
+        assert result == {"error": "Subscription 'missing-subscription' was not found"}
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_redis_error(self, mock_redis_connection_manager):
+        """Test unsubscribe when Redis returns an error."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_pubsub.unsubscribe.side_effect = RedisError("Unsubscribe failed")
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        subscription = await subscribe("test_channel")
+        result = await unsubscribe(subscription["subscription_id"])
+
+        mock_pubsub.close.assert_called_once()
+        assert result == {
+            "error": (
+                f"Error unsubscribing from subscription "
+                f"'{subscription['subscription_id']}': Unsubscribe failed"
+            )
+        }
+
+    @pytest.mark.asyncio
     async def test_subscribe_with_special_characters(
         self, mock_redis_connection_manager
     ):
@@ -241,13 +405,12 @@ class TestPubSubOperations:
         mock_redis = mock_redis_connection_manager
         mock_pubsub = Mock()
         mock_redis.pubsub.return_value = mock_pubsub
-        mock_pubsub.subscribe.return_value = None
 
         special_channel = "channel:with:colons-and-dashes_and_underscores"
         result = await subscribe(special_channel)
 
         mock_pubsub.subscribe.assert_called_once_with(special_channel)
-        assert f"Subscribed to channel '{special_channel}'" in result
+        assert result["targets"] == [special_channel]
 
     @pytest.mark.asyncio
     async def test_connection_manager_called_correctly(self):
@@ -268,29 +431,23 @@ class TestPubSubOperations:
         """Test that functions have correct signatures."""
         import inspect
 
-        # Test publish function signature
         publish_sig = inspect.signature(publish)
-        publish_params = list(publish_sig.parameters.keys())
-        assert publish_params == ["channel", "message"]
+        assert list(publish_sig.parameters.keys()) == ["channel", "message"]
 
-        # Test subscribe function signature
         subscribe_sig = inspect.signature(subscribe)
-        subscribe_params = list(subscribe_sig.parameters.keys())
-        assert subscribe_params == ["channel"]
+        assert list(subscribe_sig.parameters.keys()) == ["channel"]
 
-        # Test unsubscribe function signature
+        psubscribe_sig = inspect.signature(psubscribe)
+        assert list(psubscribe_sig.parameters.keys()) == ["pattern"]
+
+        read_messages_sig = inspect.signature(read_messages)
+        assert list(read_messages_sig.parameters.keys()) == [
+            "subscription_id",
+            "timeout_ms",
+            "max_messages",
+        ]
+        assert read_messages_sig.parameters["timeout_ms"].default == 1000
+        assert read_messages_sig.parameters["max_messages"].default == 10
+
         unsubscribe_sig = inspect.signature(unsubscribe)
-        unsubscribe_params = list(unsubscribe_sig.parameters.keys())
-        assert unsubscribe_params == ["channel"]
-
-    @pytest.mark.asyncio
-    async def test_publish_large_message(self, mock_redis_connection_manager):
-        """Test publish operation with large message."""
-        mock_redis = mock_redis_connection_manager
-        mock_redis.publish.return_value = 1
-
-        large_message = "x" * 10000  # 10KB message
-        result = await publish("test_channel", large_message)
-
-        mock_redis.publish.assert_called_once_with("test_channel", large_message)
-        assert "Message published to channel 'test_channel'" in result
+        assert list(unsubscribe_sig.parameters.keys()) == ["subscription_id"]

--- a/tests/tools/test_pub_sub.py
+++ b/tests/tools/test_pub_sub.py
@@ -399,6 +399,27 @@ class TestPubSubOperations:
         assert result == {"error": "Subscription 'missing-subscription' was not found"}
 
     @pytest.mark.asyncio
+    async def test_unsubscribe_uses_asyncio_to_thread(self):
+        """Test unsubscribe offloads blocking cleanup to a worker thread."""
+        expected = {
+            "status": "success",
+            "subscription_id": "sub-123",
+            "mode": "channel",
+            "targets": ["orders"],
+        }
+
+        with (
+            patch("src.tools.pub_sub.asyncio.to_thread") as mock_to_thread,
+            patch("src.tools.pub_sub.SubscriptionManager.unsubscribe") as mock_unsub,
+        ):
+            mock_to_thread.return_value = expected
+
+            result = await unsubscribe("sub-123")
+
+            mock_to_thread.assert_awaited_once_with(mock_unsub, "sub-123")
+            assert result == expected
+
+    @pytest.mark.asyncio
     async def test_unsubscribe_redis_error(self, mock_redis_connection_manager):
         """Test unsubscribe when Redis returns an error."""
         mock_redis = mock_redis_connection_manager

--- a/tests/tools/test_pub_sub.py
+++ b/tests/tools/test_pub_sub.py
@@ -2,6 +2,8 @@
 Unit tests for src/tools/pub_sub.py
 """
 
+import threading
+import time
 from unittest.mock import Mock, patch
 
 import pytest
@@ -413,6 +415,46 @@ class TestPubSubOperations:
             "first",
             "second",
         ]
+
+    @pytest.mark.asyncio
+    async def test_read_messages_timeout_budget_starts_after_lock_acquisition(
+        self, mock_redis_connection_manager
+    ):
+        """Test timeout budget is computed after acquiring subscription lock."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        captured_timeouts = []
+
+        def capture_timeout(*args, **kwargs):
+            captured_timeouts.append(kwargs.get("timeout"))
+            return None
+
+        mock_pubsub.get_message.side_effect = capture_timeout
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        subscription = await subscribe("test_channel")
+        managed_subscription = SubscriptionManager._subscriptions[
+            subscription["subscription_id"]
+        ]
+
+        managed_subscription.lock.acquire()
+        releaser = threading.Thread(
+            target=lambda: (time.sleep(0.2), managed_subscription.lock.release())
+        )
+        releaser.start()
+
+        try:
+            result = await read_messages(
+                subscription["subscription_id"], timeout_ms=300, max_messages=1
+            )
+        finally:
+            releaser.join(timeout=1)
+            if managed_subscription.lock.locked():
+                managed_subscription.lock.release()
+
+        assert result["message_count"] == 0
+        assert captured_timeouts
+        assert captured_timeouts[0] > 0.25
 
     @pytest.mark.asyncio
     async def test_read_messages_returns_empty_list_when_no_messages(

--- a/tests/tools/test_pub_sub.py
+++ b/tests/tools/test_pub_sub.py
@@ -186,7 +186,9 @@ class TestPubSubOperations:
         mock_redis = mock_redis_connection_manager
         mock_pubsub = Mock()
         mock_redis.pubsub.return_value = mock_pubsub
-        limit_error = "Too many active subscriptions. Close unused subscriptions and try again."
+        limit_error = (
+            "Too many active subscriptions. Close unused subscriptions and try again."
+        )
 
         with patch.object(SubscriptionManager, "MAX_ACTIVE_SUBSCRIPTIONS", 1):
             first = await subscribe("test_channel_1")

--- a/tests/tools/test_pub_sub.py
+++ b/tests/tools/test_pub_sub.py
@@ -211,10 +211,11 @@ class TestPubSubOperations:
         with (
             patch.object(SubscriptionManager, "MAX_ACTIVE_SUBSCRIPTIONS", 1),
             patch.object(SubscriptionManager, "STALE_SUBSCRIPTION_TTL_SECONDS", 60),
-            patch("src.common.subscription_manager.time.time") as mock_time,
         ):
-            mock_time.side_effect = [1000, 1000, 1000, 1100, 1100, 1100]
             first = await subscribe("test_channel_1")
+            SubscriptionManager._subscriptions[
+                first["subscription_id"]
+            ].last_accessed_at = 0
             second = await subscribe("test_channel_2")
 
         assert first["status"] == "success"

--- a/tests/tools/test_pub_sub.py
+++ b/tests/tools/test_pub_sub.py
@@ -213,7 +213,7 @@ class TestPubSubOperations:
             patch.object(SubscriptionManager, "STALE_SUBSCRIPTION_TTL_SECONDS", 60),
             patch("src.common.subscription_manager.time.time") as mock_time,
         ):
-            mock_time.side_effect = [1000, 1000, 1100, 1100]
+            mock_time.side_effect = [1000, 1000, 1000, 1100, 1100, 1100]
             first = await subscribe("test_channel_1")
             second = await subscribe("test_channel_2")
 

--- a/tests/tools/test_pub_sub.py
+++ b/tests/tools/test_pub_sub.py
@@ -179,6 +179,49 @@ class TestPubSubOperations:
         }
 
     @pytest.mark.asyncio
+    async def test_subscribe_rejects_when_subscription_limit_exceeded(
+        self, mock_redis_connection_manager
+    ):
+        """Test subscribe returns a clear error when active subscription limit is reached."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_redis.pubsub.return_value = mock_pubsub
+        limit_error = "Too many active subscriptions. Close unused subscriptions and try again."
+
+        with patch.object(SubscriptionManager, "MAX_ACTIVE_SUBSCRIPTIONS", 1):
+            first = await subscribe("test_channel_1")
+            second = await subscribe("test_channel_2")
+
+        assert first["status"] == "success"
+        assert second == {"error": limit_error}
+        assert mock_pubsub.close.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_subscribe_cleans_stale_subscription_before_enforcing_limit(
+        self, mock_redis_connection_manager
+    ):
+        """Test stale subscriptions are cleaned up before capacity check."""
+        mock_redis = mock_redis_connection_manager
+        stale_pubsub = Mock()
+        fresh_pubsub = Mock()
+        mock_redis.pubsub.side_effect = [stale_pubsub, fresh_pubsub]
+
+        with (
+            patch.object(SubscriptionManager, "MAX_ACTIVE_SUBSCRIPTIONS", 1),
+            patch.object(SubscriptionManager, "STALE_SUBSCRIPTION_TTL_SECONDS", 60),
+            patch("src.common.subscription_manager.time.time") as mock_time,
+        ):
+            mock_time.side_effect = [1000, 1000, 1100, 1100]
+            first = await subscribe("test_channel_1")
+            second = await subscribe("test_channel_2")
+
+        assert first["status"] == "success"
+        assert second["status"] == "success"
+        stale_pubsub.close.assert_called_once()
+        assert first["subscription_id"] not in SubscriptionManager._subscriptions
+        assert second["subscription_id"] in SubscriptionManager._subscriptions
+
+    @pytest.mark.asyncio
     async def test_psubscribe_success(self, mock_redis_connection_manager):
         """Test successful pattern subscribe operation."""
         mock_redis = mock_redis_connection_manager

--- a/tests/tools/test_pub_sub.py
+++ b/tests/tools/test_pub_sub.py
@@ -201,6 +201,25 @@ class TestPubSubOperations:
         assert mock_pubsub.close.call_count == 1
 
     @pytest.mark.asyncio
+    async def test_subscribe_rejects_when_stale_slots_are_reserved(
+        self, mock_redis_connection_manager
+    ):
+        """Test subscription cap accounts for stale slots reserved during cleanup."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_redis.pubsub.return_value = mock_pubsub
+        limit_error = (
+            "Too many active subscriptions. Close unused subscriptions and try again."
+        )
+
+        with patch.object(SubscriptionManager, "MAX_ACTIVE_SUBSCRIPTIONS", 1):
+            SubscriptionManager._stale_slots_reserved = 1
+            result = await subscribe("test_channel")
+
+        assert result == {"error": limit_error}
+        mock_pubsub.close.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_subscribe_cleans_stale_subscription_before_enforcing_limit(
         self, mock_redis_connection_manager
     ):

--- a/tests/tools/test_pub_sub.py
+++ b/tests/tools/test_pub_sub.py
@@ -225,6 +225,44 @@ class TestPubSubOperations:
         assert second["subscription_id"] in SubscriptionManager._subscriptions
 
     @pytest.mark.asyncio
+    async def test_subscribe_stale_cleanup_continues_when_close_fails(
+        self, mock_redis_connection_manager
+    ):
+        """Test stale cleanup still processes remaining subscriptions after one close failure."""
+        mock_redis = mock_redis_connection_manager
+        failing_stale_pubsub = Mock()
+        healthy_stale_pubsub = Mock()
+        fresh_pubsub = Mock()
+
+        failing_stale_pubsub.close.side_effect = [RedisError("close failed"), None]
+        mock_redis.pubsub.side_effect = [
+            failing_stale_pubsub,
+            healthy_stale_pubsub,
+            fresh_pubsub,
+        ]
+
+        with (
+            patch.object(SubscriptionManager, "MAX_ACTIVE_SUBSCRIPTIONS", 3),
+            patch.object(SubscriptionManager, "STALE_SUBSCRIPTION_TTL_SECONDS", 60),
+        ):
+            first = await subscribe("test_channel_1")
+            second = await subscribe("test_channel_2")
+            SubscriptionManager._subscriptions[
+                first["subscription_id"]
+            ].last_accessed_at = 0
+            SubscriptionManager._subscriptions[
+                second["subscription_id"]
+            ].last_accessed_at = 0
+            third = await subscribe("test_channel_3")
+
+        assert third["status"] == "success"
+        failing_stale_pubsub.close.assert_called_once()
+        healthy_stale_pubsub.close.assert_called_once()
+        assert first["subscription_id"] in SubscriptionManager._subscriptions
+        assert second["subscription_id"] not in SubscriptionManager._subscriptions
+        assert third["subscription_id"] in SubscriptionManager._subscriptions
+
+    @pytest.mark.asyncio
     async def test_psubscribe_success(self, mock_redis_connection_manager):
         """Test successful pattern subscribe operation."""
         mock_redis = mock_redis_connection_manager

--- a/tests/tools/test_pub_sub.py
+++ b/tests/tools/test_pub_sub.py
@@ -265,6 +265,27 @@ class TestPubSubOperations:
         assert third["subscription_id"] in SubscriptionManager._subscriptions
 
     @pytest.mark.asyncio
+    async def test_reset_closes_all_subscriptions_even_when_one_close_fails(
+        self, mock_redis_connection_manager
+    ):
+        """Test reset attempts to close all subscriptions despite close failures."""
+        mock_redis = mock_redis_connection_manager
+        failing_pubsub = Mock()
+        healthy_pubsub = Mock()
+        mock_redis.pubsub.side_effect = [failing_pubsub, healthy_pubsub]
+        failing_pubsub.close.side_effect = RedisError("close failed")
+
+        first = await subscribe("test_channel_1")
+        second = await subscribe("test_channel_2")
+
+        SubscriptionManager.reset()
+
+        failing_pubsub.close.assert_called_once()
+        healthy_pubsub.close.assert_called_once()
+        assert first["subscription_id"] not in SubscriptionManager._subscriptions
+        assert second["subscription_id"] not in SubscriptionManager._subscriptions
+
+    @pytest.mark.asyncio
     async def test_psubscribe_success(self, mock_redis_connection_manager):
         """Test successful pattern subscribe operation."""
         mock_redis = mock_redis_connection_manager


### PR DESCRIPTION
## Summary

This changes the pub/sub tools from fire-and-forget calls into usable MCP subscriptions.

Previously, subscribe() and unsubscribe() each created a fresh Redis pubsub() object and returned immediately, which meant the server did not preserve any live subscription state and MCP clients had no way to actually read published messages. This PR adds a server-side subscription manager and exposes a complete pub/sub flow through MCP tools.

## What changed

  - Added SubscriptionManager to own live Redis pubsub objects in the server process
  - Updated subscribe() to create a persistent subscription and return a subscription_id
  - Added psubscribe() for pattern subscriptions
  - Added read_messages(subscription_id, timeout_ms, max_messages) to poll queued pub/sub messages
  - Updated unsubscribe(subscription_id) to close the original live subscription instead of creating a new pubsub() instance
  - Added fixture cleanup for subscription state between tests
  - Updated README and integration expectations for the new tool surface

## Why

Redis Pub/Sub requires a live subscribed client connection to receive pushed messages. Without storing the pubsub object server-side, the existing MCP tools could acknowledge a subscription request but could not actually deliver messages to the MCP client afterward.

This PR makes the pub/sub tools operationally real:
  - the MCP server owns the live subscriber
  - the client gets a serializable subscription_id
  - later tool calls can read and close that same subscription

## Testing

Ran the full test suite locally: /Users/nishanthprakash/mcp-redis/.venv/bin/python -m pytest

## Result:
  - 335 passed


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces long-lived pub/sub connections and in-memory subscription state with concurrency and capacity limits; breaking MCP tool contract for subscribe/unsubscribe.
> 
> **Overview**
> Pub/sub MCP tools now keep **live Redis connections** in-process instead of one-off `pubsub()` calls that could not deliver messages.
> 
> A new **`SubscriptionManager`** registers channel and pattern subscriptions, returns a **`subscription_id`**, and supports **`read_messages`** (with timeout and batch limits) plus **`unsubscribe(subscription_id)`** to close the same handle. **`psubscribe`** is added; blocking Redis work runs via **`asyncio.to_thread`**. Capacity is capped (50 active), with stale subscription cleanup and structured error dicts. README, integration tool counts (53 tools), and tests reflect the new surface.
> 
> **Breaking:** `subscribe` / `unsubscribe` no longer take channel names—they use subscription handles returned from subscribe/psubscribe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03c5b69bd120b701556140ec306a98867b89dd3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->