### PR TITLE
fix: plug Pub/Sub connection leaks and fix broken unsubscribe

### DIFF
--- a/src/tools/pub_sub.py
+++ b/src/tools/pub_sub.py
@@ -1,7 +1,14 @@
+import asyncio
+
 from redis.exceptions import RedisError
 
 from src.common.connection import RedisConnectionManager
 from src.common.server import mcp
+
+# Registry of active PubSub objects keyed by channel name.
+# Required so that unsubscribe() can close the exact connection opened by subscribe().
+_subscriptions: dict[str, object] = {}
+_subscriptions_lock = asyncio.Lock()
 
 
 @mcp.tool()
@@ -33,12 +40,20 @@ async def subscribe(channel: str) -> str:
     Returns:
         A success message or an error message.
     """
+    pubsub = None
     try:
-        r = RedisConnectionManager.get_connection()
-        pubsub = r.pubsub()
-        pubsub.subscribe(channel)
+        async with _subscriptions_lock:
+            if channel in _subscriptions:
+                return f"Already subscribed to channel '{channel}'."
+            r = RedisConnectionManager.get_connection()
+            pubsub = r.pubsub()
+            pubsub.subscribe(channel)
+            _subscriptions[channel] = pubsub
+            pubsub = None  # ownership transferred to registry
         return f"Subscribed to channel '{channel}'."
     except RedisError as e:
+        if pubsub is not None:
+            pubsub.close()
         return f"Error subscribing to channel '{channel}': {str(e)}"
 
 
@@ -53,9 +68,11 @@ async def unsubscribe(channel: str) -> str:
         A success message or an error message.
     """
     try:
-        r = RedisConnectionManager.get_connection()
-        pubsub = r.pubsub()
-        pubsub.unsubscribe(channel)
+        async with _subscriptions_lock:
+            pubsub = _subscriptions.pop(channel, None)
+        if pubsub is None:
+            return f"Not subscribed to channel '{channel}'."
+        pubsub.close()
         return f"Unsubscribed from channel '{channel}'."
     except RedisError as e:
         return f"Error unsubscribing from channel '{channel}': {str(e)}"

--- a/tests/tools/test_pub_sub.py
+++ b/tests/tools/test_pub_sub.py
@@ -8,6 +8,15 @@ import pytest
 from redis.exceptions import ConnectionError, RedisError
 
 from src.tools.pub_sub import publish, subscribe, unsubscribe
+import src.tools.pub_sub as pub_sub_module
+
+
+@pytest.fixture(autouse=True)
+def reset_subscriptions():
+    """Clear the subscription registry before and after each test."""
+    pub_sub_module._subscriptions.clear()
+    yield
+    pub_sub_module._subscriptions.clear()
 
 
 class TestPubSubOperations:
@@ -111,9 +120,11 @@ class TestPubSubOperations:
         mock_redis.publish.assert_called_once_with("test_channel", unicode_message)
         assert "Message published to channel 'test_channel'" in result
 
+    # --- subscribe ---
+
     @pytest.mark.asyncio
     async def test_subscribe_success(self, mock_redis_connection_manager):
-        """Test successful subscribe operation."""
+        """Test successful subscribe operation stores pubsub in registry."""
         mock_redis = mock_redis_connection_manager
         mock_pubsub = Mock()
         mock_redis.pubsub.return_value = mock_pubsub
@@ -124,6 +135,20 @@ class TestPubSubOperations:
         mock_redis.pubsub.assert_called_once()
         mock_pubsub.subscribe.assert_called_once_with("test_channel")
         assert "Subscribed to channel 'test_channel'" in result
+        assert pub_sub_module._subscriptions["test_channel"] is mock_pubsub
+
+    @pytest.mark.asyncio
+    async def test_subscribe_already_subscribed(self, mock_redis_connection_manager):
+        """Test that subscribing to the same channel twice is idempotent."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        await subscribe("test_channel")
+        result = await subscribe("test_channel")
+
+        assert mock_redis.pubsub.call_count == 1
+        assert "Already subscribed to channel 'test_channel'" in result
 
     @pytest.mark.asyncio
     async def test_subscribe_redis_error(self, mock_redis_connection_manager):
@@ -136,10 +161,13 @@ class TestPubSubOperations:
         assert (
             "Error subscribing to channel 'test_channel': Connection failed" in result
         )
+        assert "test_channel" not in pub_sub_module._subscriptions
 
     @pytest.mark.asyncio
-    async def test_subscribe_pubsub_error(self, mock_redis_connection_manager):
-        """Test subscribe operation with pubsub creation error."""
+    async def test_subscribe_pubsub_error_closes_connection(
+        self, mock_redis_connection_manager
+    ):
+        """Test that a failed subscribe call closes the pubsub to avoid leaking."""
         mock_redis = mock_redis_connection_manager
         mock_pubsub = Mock()
         mock_redis.pubsub.return_value = mock_pubsub
@@ -148,6 +176,8 @@ class TestPubSubOperations:
         result = await subscribe("test_channel")
 
         assert "Error subscribing to channel 'test_channel': Subscribe failed" in result
+        mock_pubsub.close.assert_called_once()
+        assert "test_channel" not in pub_sub_module._subscriptions
 
     @pytest.mark.asyncio
     async def test_subscribe_multiple_channels_pattern(
@@ -166,74 +196,6 @@ class TestPubSubOperations:
         assert f"Subscribed to channel '{pattern_channel}'" in result
 
     @pytest.mark.asyncio
-    async def test_unsubscribe_success(self, mock_redis_connection_manager):
-        """Test successful unsubscribe operation."""
-        mock_redis = mock_redis_connection_manager
-        mock_pubsub = Mock()
-        mock_redis.pubsub.return_value = mock_pubsub
-        mock_pubsub.unsubscribe.return_value = None
-
-        result = await unsubscribe("test_channel")
-
-        mock_redis.pubsub.assert_called_once()
-        mock_pubsub.unsubscribe.assert_called_once_with("test_channel")
-        assert "Unsubscribed from channel 'test_channel'" in result
-
-    @pytest.mark.asyncio
-    async def test_unsubscribe_redis_error(self, mock_redis_connection_manager):
-        """Test unsubscribe operation with Redis error."""
-        mock_redis = mock_redis_connection_manager
-        mock_redis.pubsub.side_effect = RedisError("Connection failed")
-
-        result = await unsubscribe("test_channel")
-
-        assert (
-            "Error unsubscribing from channel 'test_channel': Connection failed"
-            in result
-        )
-
-    @pytest.mark.asyncio
-    async def test_unsubscribe_pubsub_error(self, mock_redis_connection_manager):
-        """Test unsubscribe operation with pubsub error."""
-        mock_redis = mock_redis_connection_manager
-        mock_pubsub = Mock()
-        mock_redis.pubsub.return_value = mock_pubsub
-        mock_pubsub.unsubscribe.side_effect = RedisError("Unsubscribe failed")
-
-        result = await unsubscribe("test_channel")
-
-        assert (
-            "Error unsubscribing from channel 'test_channel': Unsubscribe failed"
-            in result
-        )
-
-    @pytest.mark.asyncio
-    async def test_unsubscribe_from_all_channels(self, mock_redis_connection_manager):
-        """Test unsubscribe operation without specifying channel (unsubscribe from all)."""
-        mock_redis = mock_redis_connection_manager
-        mock_pubsub = Mock()
-        mock_redis.pubsub.return_value = mock_pubsub
-        mock_pubsub.unsubscribe.return_value = None
-
-        # Test unsubscribing from specific channel
-        result = await unsubscribe("specific_channel")
-
-        mock_pubsub.unsubscribe.assert_called_once_with("specific_channel")
-        assert "Unsubscribed from channel 'specific_channel'" in result
-
-    @pytest.mark.asyncio
-    async def test_publish_to_pattern_channel(self, mock_redis_connection_manager):
-        """Test publish operation to pattern-like channel."""
-        mock_redis = mock_redis_connection_manager
-        mock_redis.publish.return_value = 5
-
-        pattern_channel = "user:123:notifications"
-        result = await publish(pattern_channel, "User notification")
-
-        mock_redis.publish.assert_called_once_with(pattern_channel, "User notification")
-        assert f"Message published to channel '{pattern_channel}'" in result
-
-    @pytest.mark.asyncio
     async def test_subscribe_with_special_characters(
         self, mock_redis_connection_manager
     ):
@@ -248,6 +210,121 @@ class TestPubSubOperations:
 
         mock_pubsub.subscribe.assert_called_once_with(special_channel)
         assert f"Subscribed to channel '{special_channel}'" in result
+
+    # --- unsubscribe ---
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_success(self, mock_redis_connection_manager):
+        """Test successful unsubscribe closes the stored pubsub connection."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_redis.pubsub.return_value = mock_pubsub
+        mock_pubsub.subscribe.return_value = None
+
+        await subscribe("test_channel")
+        result = await unsubscribe("test_channel")
+
+        mock_pubsub.close.assert_called_once()
+        assert "Unsubscribed from channel 'test_channel'" in result
+        assert "test_channel" not in pub_sub_module._subscriptions
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_uses_stored_pubsub_not_new_one(
+        self, mock_redis_connection_manager
+    ):
+        """Test that unsubscribe does NOT create a new pubsub object."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        await subscribe("test_channel")
+        assert mock_redis.pubsub.call_count == 1
+
+        await unsubscribe("test_channel")
+
+        # pubsub() must still have been called exactly once (from subscribe only)
+        assert mock_redis.pubsub.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_not_subscribed(self, mock_redis_connection_manager):
+        """Test unsubscribe when no subscription exists returns a clear message."""
+        result = await unsubscribe("unknown_channel")
+
+        assert "Not subscribed to channel 'unknown_channel'" in result
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_redis_error(self, mock_redis_connection_manager):
+        """Test unsubscribe when pubsub.close() raises a RedisError."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_redis.pubsub.return_value = mock_pubsub
+        mock_pubsub.subscribe.return_value = None
+        mock_pubsub.close.side_effect = RedisError("Close failed")
+
+        await subscribe("test_channel")
+        result = await unsubscribe("test_channel")
+
+        assert (
+            "Error unsubscribing from channel 'test_channel': Close failed" in result
+        )
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_removes_from_registry(
+        self, mock_redis_connection_manager
+    ):
+        """Test that after unsubscribe the channel is removed from the registry."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub = Mock()
+        mock_redis.pubsub.return_value = mock_pubsub
+
+        await subscribe("test_channel")
+        assert "test_channel" in pub_sub_module._subscriptions
+
+        await unsubscribe("test_channel")
+        assert "test_channel" not in pub_sub_module._subscriptions
+
+    # --- lifecycle ---
+
+    @pytest.mark.asyncio
+    async def test_subscribe_unsubscribe_resubscribe(
+        self, mock_redis_connection_manager
+    ):
+        """Test that a channel can be re-subscribed after unsubscribe."""
+        mock_redis = mock_redis_connection_manager
+        mock_pubsub_1 = Mock()
+        mock_pubsub_2 = Mock()
+        mock_redis.pubsub.side_effect = [mock_pubsub_1, mock_pubsub_2]
+
+        await subscribe("test_channel")
+        await unsubscribe("test_channel")
+        result = await subscribe("test_channel")
+
+        assert "Subscribed to channel 'test_channel'" in result
+        assert pub_sub_module._subscriptions["test_channel"] is mock_pubsub_2
+
+    @pytest.mark.asyncio
+    async def test_publish_to_pattern_channel(self, mock_redis_connection_manager):
+        """Test publish operation to pattern-like channel."""
+        mock_redis = mock_redis_connection_manager
+        mock_redis.publish.return_value = 5
+
+        pattern_channel = "user:123:notifications"
+        result = await publish(pattern_channel, "User notification")
+
+        mock_redis.publish.assert_called_once_with(pattern_channel, "User notification")
+        assert f"Message published to channel '{pattern_channel}'" in result
+
+    @pytest.mark.asyncio
+    async def test_publish_large_message(self, mock_redis_connection_manager):
+        """Test publish operation with large message."""
+        mock_redis = mock_redis_connection_manager
+        mock_redis.publish.return_value = 1
+
+        large_message = "x" * 10000  # 10KB message
+        result = await publish("test_channel", large_message)
+
+        mock_redis.publish.assert_called_once_with("test_channel", large_message)
+        assert "Message published to channel 'test_channel'" in result
 
     @pytest.mark.asyncio
     async def test_connection_manager_called_correctly(self):
@@ -282,15 +359,3 @@ class TestPubSubOperations:
         unsubscribe_sig = inspect.signature(unsubscribe)
         unsubscribe_params = list(unsubscribe_sig.parameters.keys())
         assert unsubscribe_params == ["channel"]
-
-    @pytest.mark.asyncio
-    async def test_publish_large_message(self, mock_redis_connection_manager):
-        """Test publish operation with large message."""
-        mock_redis = mock_redis_connection_manager
-        mock_redis.publish.return_value = 1
-
-        large_message = "x" * 10000  # 10KB message
-        result = await publish("test_channel", large_message)
-
-        mock_redis.publish.assert_called_once_with("test_channel", large_message)
-        assert "Message published to channel 'test_channel'" in result


### PR DESCRIPTION
subscribe() was creating a pubsub object and immediately dropping it, leaking the underlying Redis connection on every call. unsubscribe() was creating a *new* pubsub object each time, so it had no knowledge of the original subscription and could never actually unsubscribe from it — leaking a second connection in the process.

Fix: introduce a module-level _subscriptions registry (dict + asyncio.Lock) that maps channel → PubSub. subscribe() stores the object; unsubscribe() retrieves and calls pubsub.close() on it, which cleanly releases the connection back to the pool. Subscribing to an already-subscribed channel is now idempotent. Errors during subscribe() explicitly close the pubsub to avoid leaking even in the failure path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Redis pub/sub lifecycle management and introduces shared in-memory state; incorrect locking/cleanup could still leak connections or break concurrent subscribe/unsubscribe behavior.
> 
> **Overview**
> Fixes Redis Pub/Sub lifecycle handling by introducing a module-level `_subscriptions` registry (guarded by an `asyncio.Lock`) so `subscribe()` retains the created PubSub object and `unsubscribe()` closes the exact connection that was opened.
> 
> Makes subscribing idempotent per channel, adds explicit cleanup on subscribe failures, and updates/expands unit tests to validate registry behavior, close-on-error, and unsubscribe semantics (including not creating a new PubSub).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b84a5f8d83e5105a8c963b003ab633acc0786b99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->