### PR TITLE
feat(string): add MGET and MSET batch string operations

### DIFF
--- a/src/tools/string.py
+++ b/src/tools/string.py
@@ -9,6 +9,61 @@ from src.common.server import mcp
 
 
 @mcp.tool()
+async def mset(mappings: dict) -> str:
+    """Set multiple Redis string values in a single atomic operation.
+
+    Args:
+        mappings (dict): A dictionary of key-value pairs to set.
+
+    Returns:
+        str: Confirmation message or an error message.
+    """
+    if not mappings:
+        return "Error: mappings cannot be empty"
+
+    try:
+        r: Redis = RedisConnectionManager.get_connection()
+        encoded = {
+            k: (v if isinstance(v, bytes) else json.dumps(v).encode("utf-8") if isinstance(v, dict) else str(v).encode("utf-8"))
+            for k, v in mappings.items()
+        }
+        r.mset(encoded)
+        return f"Successfully set {len(mappings)} keys: {', '.join(mappings.keys())}"
+    except RedisError as e:
+        return f"Error setting keys: {str(e)}"
+
+
+@mcp.tool()
+async def mget(keys: list) -> dict:
+    """Get multiple Redis string values in a single operation.
+
+    Args:
+        keys (list): List of keys to retrieve.
+
+    Returns:
+        dict: A dictionary mapping each key to its value (or None if the key does not exist).
+    """
+    if not keys:
+        return {"error": "keys cannot be empty"}
+
+    try:
+        r: Redis = RedisConnectionManager.get_connection()
+        values = r.mget(keys)
+        result = {}
+        for key, value in zip(keys, values):
+            if value is None:
+                result[key] = None
+            else:
+                try:
+                    result[key] = value.decode("utf-8")
+                except UnicodeDecodeError:
+                    result[key] = repr(value)
+        return result
+    except RedisError as e:
+        return {"error": str(e)}
+
+
+@mcp.tool()
 async def set(
     key: str,
     value: Union[str, bytes, int, float, dict],

--- a/src/tools/string.py
+++ b/src/tools/string.py
@@ -23,11 +23,18 @@ async def mset(mappings: dict) -> str:
 
     try:
         r: Redis = RedisConnectionManager.get_connection()
-        encoded = {
-            k: (v if isinstance(v, bytes) else json.dumps(v).encode("utf-8") if isinstance(v, dict) else str(v).encode("utf-8"))
-            for k, v in mappings.items()
-        }
-        r.mset(encoded)
+        normalized = {}
+        for k, v in mappings.items():
+            if isinstance(v, dict):
+                normalized[k] = json.dumps(v)
+            elif isinstance(v, bytes):
+                try:
+                    normalized[k] = v.decode("utf-8")
+                except UnicodeDecodeError:
+                    return f"Error setting keys: value for key '{k}' is not valid UTF-8"
+            else:
+                normalized[k] = str(v)
+        r.mset(normalized)
         return f"Successfully set {len(mappings)} keys: {', '.join(mappings.keys())}"
     except RedisError as e:
         return f"Error setting keys: {str(e)}"
@@ -53,11 +60,13 @@ async def mget(keys: list) -> dict:
         for key, value in zip(keys, values):
             if value is None:
                 result[key] = None
-            else:
+            elif isinstance(value, bytes):
                 try:
                     result[key] = value.decode("utf-8")
                 except UnicodeDecodeError:
                     result[key] = repr(value)
+            else:
+                result[key] = value
         return result
     except RedisError as e:
         return {"error": str(e)}


### PR DESCRIPTION
- Add mset() tool to set multiple keys atomically in a single call
- Add mget() tool to retrieve multiple keys and return a key-value dict
- Support str/int/float/dict/bytes value encoding in mset
- Return None for missing keys in mget result

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New optional MCP tools alongside existing set/get; no changes to auth, existing set/get behavior, or expiration semantics.
> 
> **Overview**
> Adds two new MCP Redis string tools in `string.py`: **`mset`** for atomic multi-key writes and **`mget`** for bulk reads.
> 
> **`mset`** accepts a `mappings` dict, rejects empty input, normalizes values (JSON for dicts, UTF-8 decode for bytes with a hard error on invalid UTF-8, `str()` otherwise), then calls Redis `MSET` and returns a success string listing keys.
> 
> **`mget`** accepts a key list, rejects empty input, calls Redis `MGET`, and returns a key→value dict with **`None`** for missing keys. Byte values are UTF-8 decoded when possible, otherwise returned as `repr(bytes)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eb29782fd3cfcb68123f6d58e0b8f5ebc8cf0a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->