### PR TITLE
feat: add MCP_REDIS_ALLOWED_TOOLS to expose only the named tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The Redis MCP Server is a **natural language interface** designed for agentic ap
   - [With Docker](#with-docker)
 - [Configuration](#configuration)
   - [Redis ACL](#redis-acl)
+  - [Restricting the exposed tools](#restricting-the-exposed-tools)
   - [Configuration via command line arguments](#configuration-via-command-line-arguments)
   - [Configuration via Environment Variables](#configuration-via-environment-variables)
   - [EntraID Authentication for Azure Managed Redis](#entraid-authentication-for-azure-managed-redis)
@@ -298,6 +299,45 @@ You can configure Redis ACL to restrict the access to the Redis database. For ex
 
 Configure the user via command line arguments or environment variables.
 
+Redis ACL restricts what the server may *execute*. It does not change which tools
+the server *offers* — a rejected command still comes back as a tool error after the
+agent has already decided to call it. To control the offered tools, see
+[Restricting the exposed tools](#restricting-the-exposed-tools).
+
+### Restricting the exposed tools
+
+By default the server exposes every tool. Set `MCP_REDIS_ALLOWED_TOOLS` to a
+comma-separated list of tool names to expose only those:
+
+```sh
+MCP_REDIS_ALLOWED_TOOLS="get,set,hget,hgetall,dbsize" redis-mcp-server --url redis://localhost:6379/0
+```
+
+Tools left out of the list are not registered at all, so they never appear in
+`tools/list`. This matters for agents: a tool that is visible can be planned
+around even when every call to it would be refused.
+
+Because the list is an allowlist, a tool added in a future release stays
+unavailable until you name it. Every name must match an existing tool — an
+unknown name aborts startup rather than being ignored, since silently dropping it
+would expose fewer tools than configured while looking like a working setup.
+
+In your MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "redis": {
+      "command": "uvx",
+      "args": ["--from", "redis-mcp-server@latest", "redis-mcp-server", "--url", "redis://localhost:6379/0"],
+      "env": {
+        "MCP_REDIS_ALLOWED_TOOLS": "get,set,hget,hgetall,dbsize"
+      }
+    }
+  }
+}
+```
+
 ### Configuration via command line arguments
 
 When using the CLI interface, you can configure the server with command line arguments:
@@ -354,6 +394,7 @@ If desired, you can use environment variables. Defaults are provided for all var
 | `REDIS_SSL_CERT_REQS`| Whether the client should verify the server's certificate | `"required"`  |
 | `REDIS_SSL_CA_CERTS` | Path to the trusted CA certificates file                  | None          |
 | `REDIS_CLUSTER_MODE` | Enable Redis Cluster mode                                 | `False`       |
+| `MCP_REDIS_ALLOWED_TOOLS` | Comma-separated names of the only tools to expose ([details](#restricting-the-exposed-tools)) | All tools |
 
 
 ### EntraID Authentication for Azure Managed Redis

--- a/src/common/server.py
+++ b/src/common/server.py
@@ -1,6 +1,11 @@
 import importlib
+import os
 import pkgutil
+from typing import Iterable, List, Optional
+
 from mcp.server.fastmcp import FastMCP
+
+ALLOWED_TOOLS_ENV_VAR = "MCP_REDIS_ALLOWED_TOOLS"
 
 
 def load_tools():
@@ -10,6 +15,61 @@ def load_tools():
         importlib.import_module(f"src.tools.{module_name}")
 
 
+def parse_allowed_tools(allowed_tools: Optional[str]) -> Optional[set]:
+    """Parse a comma-separated allowlist of tool names.
+
+    Returns None when no allowlist is configured, meaning every tool stays
+    available.
+    """
+    if allowed_tools is None:
+        return None
+
+    names = {name.strip() for name in allowed_tools.split(",")}
+    names.discard("")
+    return names
+
+
+def select_disallowed_tools(allowed: set, registered: Iterable[str]) -> List[str]:
+    """Return the registered tool names that the allowlist does not cover.
+
+    Raises:
+        ValueError: if the allowlist names a tool the server does not provide.
+            Dropping such a name silently would leave a narrower set of tools
+            than was configured, which is indistinguishable from the tool
+            simply not being used.
+    """
+    registered = set(registered)
+
+    unknown = sorted(allowed - registered)
+    if unknown:
+        raise ValueError(
+            f"{ALLOWED_TOOLS_ENV_VAR} names unknown "
+            f"{'tool' if len(unknown) == 1 else 'tools'}: {', '.join(unknown)}. "
+            f"Available tools: {', '.join(sorted(registered))}"
+        )
+
+    return sorted(registered - allowed)
+
+
+def apply_tool_allowlist(server: FastMCP, allowed_tools: Optional[str]) -> None:
+    """Unregister every tool that the allowlist does not name.
+
+    Unregistering rather than rejecting at call time keeps the omitted tools
+    out of `tools/list` entirely, so an agent cannot plan around a tool it is
+    not allowed to use.
+    """
+    allowed = parse_allowed_tools(allowed_tools)
+    if allowed is None:
+        return
+
+    # FastMCP exposes no synchronous accessor for its registry; `list_tools()`
+    # is a coroutine and this runs at import time.
+    registered = [tool.name for tool in server._tool_manager.list_tools()]
+
+    for name in select_disallowed_tools(allowed, registered):
+        server.remove_tool(name)
+
+
 # Initialize FastMCP server
 mcp = FastMCP(
     "Redis MCP Server", dependencies=["redis", "python-dotenv", "numpy", "aiohttp"]
@@ -17,3 +77,6 @@ mcp = FastMCP(
 
 # Load tools
 load_tools()
+
+# Restrict the exposed tools when an allowlist is configured
+apply_tool_allowlist(mcp, os.getenv(ALLOWED_TOOLS_ENV_VAR))

--- a/tests/test_tool_allowlist.py
+++ b/tests/test_tool_allowlist.py
@@ -1,0 +1,155 @@
+"""
+Unit tests for the MCP_REDIS_ALLOWED_TOOLS allowlist in src/common/server.py
+"""
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from src.common.server import (
+    ALLOWED_TOOLS_ENV_VAR,
+    apply_tool_allowlist,
+    parse_allowed_tools,
+    select_disallowed_tools,
+)
+
+
+REGISTERED = ["get_value", "set_value", "delete_value"]
+
+
+def build_server() -> FastMCP:
+    """A server with one read tool and two write tools."""
+    server = FastMCP("Test Server")
+
+    async def get_value(key: str) -> str:
+        """Read a value."""
+        return key
+
+    async def set_value(key: str, value: str) -> str:
+        """Write a value."""
+        return value
+
+    async def delete_value(key: str) -> str:
+        """Delete a value."""
+        return key
+
+    for fn in (get_value, set_value, delete_value):
+        server.add_tool(fn)
+
+    return server
+
+
+async def tool_names(server: FastMCP) -> list:
+    return sorted(tool.name for tool in await server.list_tools())
+
+
+class TestParseAllowedTools:
+    """Test cases for parsing the allowlist."""
+
+    def test_returns_none_when_unset(self):
+        assert parse_allowed_tools(None) is None
+
+    def test_splits_on_commas(self):
+        assert parse_allowed_tools("get_value,set_value") == {"get_value", "set_value"}
+
+    def test_strips_surrounding_whitespace(self):
+        assert parse_allowed_tools(" get_value , set_value ") == {
+            "get_value",
+            "set_value",
+        }
+
+    def test_ignores_empty_entries(self):
+        assert parse_allowed_tools("get_value,,set_value,") == {
+            "get_value",
+            "set_value",
+        }
+
+    def test_empty_string_allows_nothing(self):
+        """An empty allowlist is still an allowlist, unlike an unset one."""
+        assert parse_allowed_tools("") == set()
+
+
+class TestSelectDisallowedTools:
+    """Test cases for resolving the allowlist against registered tools."""
+
+    def test_returns_tools_outside_the_allowlist(self):
+        assert select_disallowed_tools({"get_value"}, REGISTERED) == [
+            "delete_value",
+            "set_value",
+        ]
+
+    def test_returns_nothing_when_every_tool_is_allowed(self):
+        assert select_disallowed_tools(set(REGISTERED), REGISTERED) == []
+
+    def test_returns_every_tool_for_an_empty_allowlist(self):
+        assert select_disallowed_tools(set(), REGISTERED) == [
+            "delete_value",
+            "get_value",
+            "set_value",
+        ]
+
+    def test_rejects_a_misspelled_name(self):
+        with pytest.raises(ValueError) as excinfo:
+            select_disallowed_tools({"get_value", "get_valu"}, REGISTERED)
+
+        message = str(excinfo.value)
+        assert "get_valu" in message
+        assert ALLOWED_TOOLS_ENV_VAR in message
+
+    def test_reports_every_unknown_name_sorted(self):
+        with pytest.raises(ValueError) as excinfo:
+            select_disallowed_tools({"zzz_missing", "aaa_missing"}, REGISTERED)
+
+        assert "aaa_missing, zzz_missing" in str(excinfo.value)
+
+    def test_error_lists_the_available_tools(self):
+        with pytest.raises(ValueError) as excinfo:
+            select_disallowed_tools({"nope"}, REGISTERED)
+
+        message = str(excinfo.value)
+        for name in REGISTERED:
+            assert name in message
+
+
+class TestApplyToolAllowlist:
+    """Test cases for applying the allowlist to a server."""
+
+    async def test_keeps_every_tool_when_unset(self):
+        server = build_server()
+        apply_tool_allowlist(server, None)
+
+        assert await tool_names(server) == [
+            "delete_value",
+            "get_value",
+            "set_value",
+        ]
+
+    async def test_omits_unnamed_tools_from_tools_list(self):
+        """The point of the allowlist: omitted tools are gone, not merely refused."""
+        server = build_server()
+        apply_tool_allowlist(server, "get_value,set_value")
+
+        assert await tool_names(server) == ["get_value", "set_value"]
+
+    async def test_keeps_a_single_named_tool(self):
+        server = build_server()
+        apply_tool_allowlist(server, "get_value")
+
+        assert await tool_names(server) == ["get_value"]
+
+    async def test_empty_allowlist_removes_every_tool(self):
+        server = build_server()
+        apply_tool_allowlist(server, "")
+
+        assert await tool_names(server) == []
+
+    async def test_unknown_name_raises_and_leaves_the_server_untouched(self):
+        server = build_server()
+
+        with pytest.raises(ValueError):
+            apply_tool_allowlist(server, "get_value,get_valu")
+
+        assert await tool_names(server) == [
+            "delete_value",
+            "get_value",
+            "set_value",
+        ]


### PR DESCRIPTION
## Problem

Every tool is registered unconditionally. `load_tools()` imports each module under `src/tools/`, the `@mcp.tool()` decorators run, and all 53 tools land in `tools/list` — including `delete`, `expire`, `rename`, `json_del`, `hdel`, `xdel`, `srem`, `zrem`, `lrem`, `xgroup_destroy` and the rest of the write surface. There is no way to hand an agent a subset.

The control the README currently points at is Redis ACL:

```
ACL SETUSER readonlyuser on >mypassword ~* +@read -@write
```

That restricts what may be *executed*, not what is *offered*. Two consequences:

1. The tool stays in the inventory. The agent sees `delete`, plans a step around it, calls it, and gets `Error deleting key foo: NOPERM ...` back as a tool result. The refusal arrives after the plan was made, not before.
2. ACL granularity is over Redis commands, not MCP tools, and it is unavailable to anyone who does not administer the Redis server — managed and shared instances included.

## Change

`MCP_REDIS_ALLOWED_TOOLS` takes a comma-separated list of tool names and exposes only those:

```sh
MCP_REDIS_ALLOWED_TOOLS="get,set,hget,hgetall,dbsize" redis-mcp-server --url redis://localhost:6379/0
```

```
tools/list = 53  →  tools/list = 5
```

Three properties, in the order they matter:

**Unregistered, not refused.** Tools outside the list are removed via the public `FastMCP.remove_tool`, so they are absent from `tools/list` rather than failing on call. A tool an agent cannot see is a tool it cannot plan around.

**Allowlist, not denylist.** A tool added in a future release stays unavailable until it is named. A denylist would ship new write tools to existing users on upgrade.

**Unknown names abort startup.** A misspelled name would otherwise be dropped silently, leaving fewer tools than configured — indistinguishable, from the outside, from the agent simply not using the tool. The error names the offending entries and lists what is available:

```
ValueError: MCP_REDIS_ALLOWED_TOOLS names unknown tool: gett.
Available tools: client_list, create_vector_index_hash, dbsize, delete, ...
```

Leaving the variable unset changes nothing — all 53 tools stay available, so this is inert for existing users.

## Tests

`tests/test_tool_allowlist.py`, 16 cases across three groups: parsing (unset vs. empty vs. whitespace vs. stray commas), resolution against the registered set (subset, full set, empty, one typo, several typos sorted, error contents), and application to a real `FastMCP` instance asserted through `list_tools()` — including that an unknown name raises and leaves the server untouched.

Verified locally against the checks in `.github/workflows/ci.yml`: full suite **361 passed**, coverage **88.46%** (gate 80%), `ruff format --check` clean, `bandit -r src/` clean, and the startup smoke test passes. End-to-end runs confirm 53 → 3 tool inventories and the abort-on-typo path through `src/main.py`.

## Notes

Two things I would rather you decide than assume:

`apply_tool_allowlist` reads `server._tool_manager.list_tools()` to enumerate what is registered. `FastMCP` exposes no synchronous accessor — `list_tools()` is a coroutine and this runs at import time. Happy to switch to `asyncio.run` or to track names at registration if you prefer to avoid the private attribute.

The failure on an unknown name is a `ValueError` raised at import, so it surfaces as a traceback rather than a `click` error, because `src/common/server.py` is imported before `cli()` runs. If you would rather it print through `click.echo(..., err=True)` and `sys.exit(1)` like the URI parsing error in `main.py`, that needs the import restructured and I did not want to do that unasked.

A `read-only` baseline keyword (`read-only` plus named write tools, rather than naming every read tool) is the natural follow-up and is how I implemented the equivalent in [chigwell/telegram-mcp#168](https://github.com/chigwell/telegram-mcp/pull/168). It needs each of the 53 tools classified, which is a judgement call per tool, so I left it out of this PR rather than bundle it. Glad to add it if you want it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Misconfigured allowlists can hide needed tools or block startup on typos; default behavior is unchanged when unset, but this directly shapes agent capabilities at the MCP boundary.
> 
> **Overview**
> Adds **`MCP_REDIS_ALLOWED_TOOLS`**, a comma-separated **allowlist** so operators can shrink what agents see in `tools/list` without relying on Redis ACL alone (ACL still blocks execution but leaves forbidden tools visible and plan-able).
> 
> After tools load, **`apply_tool_allowlist`** unregisters anything not named via `FastMCP.remove_tool`, so omitted tools never appear in the catalog. Unknown names **fail startup** with a `ValueError` listing available tools; an empty string allowlists nothing; unset keeps all tools (backward compatible).
> 
> README documents the new env var, contrasts ACL vs tool exposure, and adds MCP client config examples. **`tests/test_tool_allowlist.py`** covers parsing, resolution, and live `list_tools()` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8b3049fabc81d30fae5065b0cd0d5689401721c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->