### PR TITLE
fix: pin mcp to <2 (2.0.0 removed mcp.server.fastmcp)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "mcp[cli]>=1.26.0",
+    "mcp[cli]>=1.26.0,<2",
     "redis>=6.0.0",
     "python-dotenv>=1.0.1",
     "numpy>=2.2.4",

--- a/uv.lock
+++ b/uv.lock
@@ -2290,7 +2290,7 @@ test = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.0" },
     { name = "click", specifier = ">=8.0.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.26.0,<2" },
     { name = "numpy", specifier = ">=2.2.4" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "redis", specifier = ">=6.0.0" },


### PR DESCRIPTION
Fixes #163.

`mcp` 2.0.0 (released 28 July 2026) removed the `mcp.server.fastmcp` package — the FastMCP server now lives under `mcp.server.mcpserver`. Since `pyproject.toml` declares `mcp[cli]>=1.26.0` with no upper bound, any fresh resolution picks up 2.0.0 and the server fails to start:

```
File ".../site-packages/src/common/server.py", line 3, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

This affects both installation paths documented in the README (`pip install redis-mcp-server` and `uvx --from redis-mcp-server@latest`), and it is what has been turning the nightly `build-test` job red since 29 July — the `⚙️ Test package installation` step is the only one that installs the built wheel without `uv.lock`, so it is the only job that sees what users actually get.

This PR adds the upper bound, and updates the matching `requires-dist` entry in `uv.lock` so the lockfile stays consistent (`uv lock --check` passes; the resolved version is unchanged at 1.28.1).

Verified locally by reproducing the failing CI step against the wheel built from this branch:

```console
$ uv build --sdist --wheel
$ python3 -m venv verify-venv && ./verify-venv/bin/pip install dist/*.whl
$ ./verify-venv/bin/pip show mcp | head -2
Name: mcp
Version: 1.29.0
$ ./verify-venv/bin/redis-mcp-server --help
Usage: redis-mcp-server [OPTIONS]
  Redis MCP Server - Model Context Protocol server for Redis.
```

Two things this PR deliberately does not do, both noted in #163:

- **It does not fix the already-published 0.5.0.** That wheel is on PyPI with `mcp[cli]>=1.9.4` and will keep resolving to 2.0.0 until a patch release goes out.
- **It does not migrate to `mcp` 2.x.** `src/common/server.py` constructs `FastMCP` directly and `tests/test_server.py` asserts on the `mcp.server.fastmcp.server.FastMCP` type in several places, so that migration is a larger change and a separate decision. Pinning `<2` is the minimal fix that restores installs today.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only tightens the declared dependency range and lock metadata; no runtime logic changes.
> 
> **Overview**
> Pins **`mcp[cli]`** to **`>=1.26.0,<2`** in `pyproject.toml` and mirrors the same specifier in **`uv.lock`** so fresh installs no longer resolve **`mcp` 2.x**, which removed **`mcp.server.fastmcp`** and breaks server startup (`ModuleNotFoundError` on `FastMCP`).
> 
> This is a dependency-only fix; no application or test code changes. The lockfile’s resolved **`mcp`** version stays on the 1.x line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faeb09fc1f8a6d7d1c73356cdf54339ea86b16e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->