### PR TITLE
fix(cli): preserve environment configuration when flags are omitted

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -28,20 +28,20 @@ class RedisMCPServer:
     "--url",
     help="Redis connection URI (redis://user:pass@host:port/db or rediss:// for SSL)",
 )
-@click.option("--host", default="127.0.0.1", help="Redis host")
-@click.option("--port", default=6379, type=int, help="Redis port")
-@click.option("--db", default=0, type=int, help="Redis database number")
+@click.option("--host", help="Redis host")
+@click.option("--port", type=int, help="Redis port")
+@click.option("--db", type=int, help="Redis database number")
 @click.option("--username", help="Redis username")
 @click.option("--password", help="Redis password")
-@click.option("--ssl", is_flag=True, help="Use SSL connection")
+@click.option("--ssl", is_flag=True, default=None, help="Use SSL connection")
 @click.option("--ssl-ca-path", help="Path to CA certificate file")
 @click.option("--ssl-keyfile", help="Path to SSL key file")
 @click.option("--ssl-certfile", help="Path to SSL certificate file")
-@click.option(
-    "--ssl-cert-reqs", default="required", help="SSL certificate requirements"
-)
+@click.option("--ssl-cert-reqs", help="SSL certificate requirements")
 @click.option("--ssl-ca-certs", help="Path to CA certificates file")
-@click.option("--cluster-mode", is_flag=True, help="Enable Redis cluster mode")
+@click.option(
+    "--cluster-mode", is_flag=True, default=None, help="Enable Redis cluster mode"
+)
 # Entra ID Authentication Options
 @click.option(
     "--entraid-auth-flow",
@@ -127,14 +127,18 @@ def cli(
             sys.exit(1)
     else:
         # Set individual Redis parameters
-        config = {
-            "host": host,
-            "port": port,
-            "db": db,
-            "ssl": ssl,
-            "cluster_mode": cluster_mode,
-        }
+        config = {}
 
+        if host is not None:
+            config["host"] = host
+        if port is not None:
+            config["port"] = port
+        if db is not None:
+            config["db"] = db
+        if ssl is not None:
+            config["ssl"] = ssl
+        if cluster_mode is not None:
+            config["cluster_mode"] = cluster_mode
         if username:
             config["username"] = username
         if password:
@@ -145,7 +149,7 @@ def cli(
             config["ssl_keyfile"] = ssl_keyfile
         if ssl_certfile:
             config["ssl_certfile"] = ssl_certfile
-        if ssl_cert_reqs:
+        if ssl_cert_reqs is not None:
             config["ssl_cert_reqs"] = ssl_cert_reqs
         if ssl_ca_certs:
             config["ssl_ca_certs"] = ssl_ca_certs

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -206,15 +206,29 @@ class TestCLI:
         result = self.runner.invoke(cli, [])
 
         assert result.exit_code == 0
-        # Should be called with empty config when no parameters provided
-        mock_set_config.assert_called_once()
-        call_args = mock_set_config.call_args[0][0]
+        mock_set_config.assert_called_once_with({})
 
-        # Check that only non-None values are in the config
-        for key, value in call_args.items():
-            if value is not None:
-                # These should be the default values or explicitly set values
-                assert isinstance(value, (str, int, bool))
+    @patch("src.main.RedisMCPServer")
+    def test_cli_without_options_preserves_environment_config(self, mock_server_class):
+        """CLI defaults should not replace configuration loaded from the environment."""
+        mock_server = Mock()
+        mock_server_class.return_value = mock_server
+        environment_config = {
+            "host": "redis.internal",
+            "port": 6380,
+            "db": 4,
+            "ssl": True,
+            "ssl_cert_reqs": "optional",
+            "cluster_mode": True,
+        }
+
+        with patch.dict(
+            "src.common.config.REDIS_CFG", environment_config, clear=True
+        ) as redis_config:
+            result = self.runner.invoke(cli, [])
+
+            assert result.exit_code == 0
+            assert redis_config == environment_config
 
     @patch("src.main.parse_redis_uri")
     @patch("src.main.set_redis_config_from_cli")


### PR DESCRIPTION
## Summary

Fixes #156.

The console entrypoint now leaves environment-loaded Redis settings unchanged when their matching CLI options are omitted. Explicit CLI arguments and `--url` still take precedence.

## Changes

- Remove always-present Click defaults for individual Redis connection options.
- Pass only explicitly provided host, port, database, SSL, certificate requirement, and cluster values to the configuration setter.
- Strengthen the default-options test and add a regression test that invokes the CLI with non-default environment configuration already loaded.

## Testing

- `uv run pytest tests/ -q` — 346 passed, 88.32% coverage
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run bandit -r src/`
- `uv run --isolated --python 3.12 pytest tests/test_main.py -q --no-cov` — 14 passed
- `uv build --sdist --wheel`
- `uv run twine check dist/*`
